### PR TITLE
Connect an admin room to a Rocket.Chat server

### DIFF
--- a/assets/translations.yaml
+++ b/assets/translations.yaml
@@ -1,4 +1,6 @@
 en:
+  admin_command:
+    successfully_connected: You are connected to ${rocketchat_url}.
   admin_room:
     connection_instructions: |
       Hi, I'm the Rocket.Chat application service

--- a/migrations/20161204155847_create_users/up.sql
+++ b/migrations/20161204155847_create_users/up.sql
@@ -1,9 +1,12 @@
 CREATE TABLE users (
   matrix_user_id VARCHAR NOT NULL,
+  rocketchat_user_id VARCHAR,
+  display_name VARCHAR NOT NULL,
   language VARCHAR NOT NULL,
   is_virtual_user BOOLEAN NOT NULL,
   last_message_sent BIG INT NOT NULL DEFAULT 0,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (rocketchat_user_id),
   CONSTRAINT users_pk PRIMARY KEY (matrix_user_id)
 );

--- a/migrations/20161204173030_create_rooms/up.sql
+++ b/migrations/20161204173030_create_rooms/up.sql
@@ -2,6 +2,7 @@ CREATE TABLE rooms (
   matrix_room_id VARCHAR NOT NULL,
   display_name VARCHAR NOT NULL,
   rocketchat_room_id VARCHAR,
+  rocketchat_server_id INTEGER,
   is_admin_room BOOLEAN NOT NULL DEFAULT false,
   is_bridged BOOLEAN NOT NULL DEFAULT false,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/migrations/20170121174542_create_rocketchat_servers/down.sql
+++ b/migrations/20170121174542_create_rocketchat_servers/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE rocketchat_servers;

--- a/migrations/20170121174542_create_rocketchat_servers/up.sql
+++ b/migrations/20170121174542_create_rocketchat_servers/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE rocketchat_servers (
+  id INTEGER PRIMARY KEY,
+  rocketchat_url VARCHAR NOT NULL,
+  rocketchat_token VARCHAR,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (rocketchat_url),
+  UNIQUE (rocketchat_token)
+)

--- a/migrations/20170121180854_create_users_on_rocketchat_servers/down.sql
+++ b/migrations/20170121180854_create_users_on_rocketchat_servers/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE users_on_rocketchat_servers;

--- a/migrations/20170121180854_create_users_on_rocketchat_servers/up.sql
+++ b/migrations/20170121180854_create_users_on_rocketchat_servers/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE users_on_rocketchat_servers (
+  matrix_user_id VARCHAR NOT NULL,
+  rocketchat_server_id INTEGER NOT NULL,
+  rocketchat_auth_token VARCHAR,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)

--- a/src/matrix-rocketchat/api/mod.rs
+++ b/src/matrix-rocketchat/api/mod.rs
@@ -2,8 +2,11 @@
 
 /// Matrix REST API
 pub mod matrix;
-/// REST API
+/// Generic REST API
 pub mod rest_api;
+/// Rocket.Chat REST API
+pub mod rocketchat;
 
 pub use self::matrix::MatrixApi;
 pub use self::rest_api::RestApi;
+pub use self::rocketchat::RocketchatApi;

--- a/src/matrix-rocketchat/api/rocketchat/mod.rs
+++ b/src/matrix-rocketchat/api/rocketchat/mod.rs
@@ -36,6 +36,7 @@ impl RocketchatApi {
         let (body, status_code) = match RestApi::call(Method::Get, &url, "", &params, None) {
             Ok((body, status_code)) => (body, status_code),
             Err(err) => {
+                debug!(logger, err);
                 bail!(ErrorKind::RocketchatServerUnreachable(url));
             }
         };

--- a/src/matrix-rocketchat/api/rocketchat/mod.rs
+++ b/src/matrix-rocketchat/api/rocketchat/mod.rs
@@ -15,12 +15,6 @@ pub trait RocketchatApi {}
 /// Response format when querying the Rocket.Chat info endpoint
 #[derive(Deserialize, Serialize)]
 pub struct GetInfoResponse {
-    info: InfoContent,
-}
-
-/// The content of the Rocket.Chat info response
-#[derive(Deserialize, Serialize)]
-pub struct InfoContent {
     version: String,
 }
 
@@ -48,9 +42,9 @@ impl RocketchatApi {
         let rocketchat_info: GetInfoResponse =
             serde_json::from_str(&body).chain_err(|| ErrorKind::NoRocketchatServer(url))?;
 
-        debug!(logger, format!("Rocket.Chat version {:?}", rocketchat_info.info.version));
+        debug!(logger, format!("Rocket.Chat version {:?}", rocketchat_info.version));
 
-        RocketchatApi::get_max_supported_version_api(rocketchat_info.info.version, base_url, access_token, logger)
+        RocketchatApi::get_max_supported_version_api(rocketchat_info.version, base_url, access_token, logger)
     }
 
     fn get_max_supported_version_api(version: String,
@@ -68,6 +62,6 @@ impl RocketchatApi {
             return Ok(Box::new(rocketchat_api));
         }
 
-        Err(Error::from(ErrorKind::UnsupportedRocketchatApiVersion(version)))
+        Err(Error::from(ErrorKind::UnsupportedRocketchatApiVersion("0.49".to_string(), version)))
     }
 }

--- a/src/matrix-rocketchat/api/rocketchat/mod.rs
+++ b/src/matrix-rocketchat/api/rocketchat/mod.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+
+use reqwest::Method;
+use serde_json;
+use slog::Logger;
+
+use api::RestApi;
+use config::Config;
+use errors::*;
+
+mod v1;
+
+/// Rocket.Chat REST API
+pub trait RocketchatApi: Send + Sync + RocketchatApiClone {}
+
+/// Response format when querying the Rocket.Chat info endpoint
+#[derive(Deserialize, Serialize)]
+pub struct GetInfoResponse {
+    info: InfoContent,
+}
+
+/// The content of the Rocket.Chat info response
+#[derive(Deserialize, Serialize)]
+pub struct InfoContent {
+    version: String,
+}
+
+/// Helper trait because Clone cannot be part of the `RocketchatApi` trait since that would cause the
+/// `RocketchatApi` trait to not be object safe.
+pub trait RocketchatApiClone {
+    /// Clone the object inside the trait and return it in box.
+    fn clone_box(&self) -> Box<RocketchatApi>;
+}
+
+impl<T> RocketchatApiClone for T
+    where T: 'static + RocketchatApi + Clone
+{
+    fn clone_box(&self) -> Box<RocketchatApi> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<RocketchatApi> {
+    fn clone(&self) -> Box<RocketchatApi> {
+        self.clone_box()
+    }
+}
+
+impl RocketchatApi {
+    /// Creates a new Rocket.Chat API depending on the version of the API.
+    /// It returns a `RocketchatApi` trait, because for each version a different API is created.
+    pub fn new(base_url: String, access_token: Option<String>, logger: Logger) -> Result<Box<RocketchatApi>> {
+        let url = base_url.clone() + "/api/info";
+        let params = HashMap::new();
+
+        debug!(logger, format!("Querying Rocket.Chat server {} for API versions", url));
+
+        let (body, status_code) = RestApi::call(Method::Get, &url, "", &params, None)?;
+        if !status_code.is_success() {
+            let rocketchat_error_resp: RocketchatErrorResponse = serde_json::from_str(&body).chain_err(|| {
+                    ErrorKind::InvalidJSON(format!("Could not deserialize error response from Rocket.Chat info API \
+                                                    endpoint: `{}` ",
+                                                   body))
+                })?;
+            bail!(ErrorKind::RocketchatError(rocketchat_error_resp.message));
+        }
+
+        let rocketchat_info: GetInfoResponse = serde_json::from_str(&body).chain_err(|| {
+                ErrorKind::InvalidJSON(format!("Could not deserialize response from Rocket.Chat info API \
+                                                endpoint: `{}`",
+                                               body))
+            })?;
+
+        debug!(logger, format!("Rocket.Chat version {:?}", rocketchat_info.info.version));
+
+        RocketchatApi::get_max_supported_version_api(rocketchat_info.info.version, base_url, access_token, logger)
+    }
+
+    fn get_max_supported_version_api(version: String,
+                                     base_url: String,
+                                     access_token: Option<String>,
+                                     logger: Logger)
+                                     -> Result<Box<RocketchatApi>> {
+        let major = 0;
+        let minor = 0;
+
+        let version_string = version.clone();
+        let mut versions = version_string.split(".").into_iter();
+        let major: i32 = versions.next().unwrap_or("0").parse().unwrap_or(0);
+        let minor: i32 = versions.next().unwrap_or("0").parse().unwrap_or(0);
+
+        if major == 0 && minor >= 49 {
+            let rocketchat_api = v1::RocketchatApi::new(base_url, access_token, logger);
+            return Ok(Box::new(rocketchat_api));
+        }
+
+        Err(Error::from(ErrorKind::UnsupportedRocketchatApiVersion(version)))
+    }
+}

--- a/src/matrix-rocketchat/api/rocketchat/mod.rs
+++ b/src/matrix-rocketchat/api/rocketchat/mod.rs
@@ -5,7 +5,6 @@ use serde_json;
 use slog::Logger;
 
 use api::RestApi;
-use config::Config;
 use errors::*;
 
 mod v1;
@@ -58,9 +57,6 @@ impl RocketchatApi {
                                      access_token: Option<String>,
                                      logger: Logger)
                                      -> Result<Box<RocketchatApi>> {
-        let major = 0;
-        let minor = 0;
-
         let version_string = version.clone();
         let mut versions = version_string.split(".").into_iter();
         let major: i32 = versions.next().unwrap_or("0").parse().unwrap_or(0);

--- a/src/matrix-rocketchat/api/rocketchat/v1.rs
+++ b/src/matrix-rocketchat/api/rocketchat/v1.rs
@@ -1,0 +1,29 @@
+use serde_json::Map;
+use slog::Logger;
+use serde_json;
+
+use api::RestApi;
+use config::Config;
+use errors::*;
+
+#[derive(Clone)]
+pub struct RocketchatApi {
+    /// URL to call the API
+    pub base_url: String,
+    /// Access token for authentication
+    pub access_token: Option<String>,
+    /// Logger passed to the Rocketchat API
+    logger: Logger,
+}
+
+impl RocketchatApi {
+    pub fn new(base_url: String, access_token: Option<String>, logger: Logger) -> RocketchatApi {
+        RocketchatApi {
+            base_url: base_url,
+            access_token: access_token,
+            logger: logger,
+        }
+    }
+}
+
+impl super::RocketchatApi for RocketchatApi {}

--- a/src/matrix-rocketchat/api/rocketchat/v1.rs
+++ b/src/matrix-rocketchat/api/rocketchat/v1.rs
@@ -1,10 +1,4 @@
-use serde_json::Map;
 use slog::Logger;
-use serde_json;
-
-use api::RestApi;
-use config::Config;
-use errors::*;
 
 #[derive(Clone)]
 pub struct RocketchatApi {

--- a/src/matrix-rocketchat/db/mod.rs
+++ b/src/matrix-rocketchat/db/mod.rs
@@ -2,6 +2,8 @@
 
 /// Database connection pool
 pub mod connection_pool;
+/// `RocketchatServer` entry
+pub mod rocketchat_server;
 /// `Room` entry
 pub mod room;
 /// The database schema
@@ -10,8 +12,12 @@ pub mod schema;
 pub mod user;
 /// `UserInRoom` entry
 pub mod user_in_room;
+/// `UserOnRocketchatServer` entry
+pub mod user_on_rocketchat_server;
 
 pub use self::connection_pool::ConnectionPool;
-pub use self::room::Room;
-pub use self::user::User;
-pub use self::user_in_room::UserInRoom;
+pub use self::rocketchat_server::{NewRocketchatServer, RocketchatServer};
+pub use self::room::{NewRoom, Room};
+pub use self::user::{NewUser, User};
+pub use self::user_in_room::{NewUserInRoom, UserInRoom};
+pub use self::user_on_rocketchat_server::{NewUserOnRocketchatServer, UserOnRocketchatServer};

--- a/src/matrix-rocketchat/db/rocketchat_server.rs
+++ b/src/matrix-rocketchat/db/rocketchat_server.rs
@@ -32,18 +32,11 @@ pub struct NewRocketchatServer {
 }
 
 impl RocketchatServer {
-    /// Insert or update a `RocketchatServer`.
-    pub fn upsert(connection: &SqliteConnection, new_rocketchat_server: &NewRocketchatServer) -> Result<RocketchatServer> {
-        match RocketchatServer::find_by_url(connection, new_rocketchat_server.rocketchat_url.clone())? {
-            Some(rocketchat_server) => {
-                diesel::update(rocketchat_servers::table.find(rocketchat_server.id)).set(rocketchat_servers::rocketchat_token.eq::<Option<String>>(new_rocketchat_server.rocketchat_token.clone())).execute(connection).chain_err(|| ErrorKind::DBUpdateError)?;
-            }
-            None => {
-                diesel::insert(new_rocketchat_server).into(rocketchat_servers::table)
-                    .execute(connection)
-                    .chain_err(|| ErrorKind::DBInsertError)?;
-            }
-        }
+    /// Insert a `RocketchatServer`.
+    pub fn insert(connection: &SqliteConnection, new_rocketchat_server: &NewRocketchatServer) -> Result<RocketchatServer> {
+        diesel::insert(new_rocketchat_server).into(rocketchat_servers::table)
+            .execute(connection)
+            .chain_err(|| ErrorKind::DBInsertError)?;
 
         let rocketchat_server = RocketchatServer::find_by_url(connection, new_rocketchat_server.rocketchat_url.clone())
             ?

--- a/src/matrix-rocketchat/db/rocketchat_server.rs
+++ b/src/matrix-rocketchat/db/rocketchat_server.rs
@@ -1,0 +1,69 @@
+use diesel;
+use diesel::prelude::*;
+use diesel::sqlite::SqliteConnection;
+
+use errors::*;
+use super::schema::rocketchat_servers;
+
+/// A Rocket.Chat server.
+#[derive(Debug, Identifiable, Queryable)]
+#[table_name="rocketchat_servers"]
+pub struct RocketchatServer {
+    /// The unique id for the Rocket.Chat server
+    pub id: i32,
+    /// The URL to connect to the Rocket.Chat server
+    pub rocketchat_url: String,
+    /// The token to identify reuqests from the Rocket.Chat server
+    pub rocketchat_token: Option<String>,
+    /// created timestamp
+    pub created_at: String,
+    /// updated timestamp
+    pub updated_at: String,
+}
+
+/// A new `Room`, not yet saved.
+#[derive(Insertable)]
+#[table_name="rocketchat_servers"]
+pub struct NewRocketchatServer {
+    /// The URL to connect to the Rocket.Chat server
+    pub rocketchat_url: String,
+    /// The token to identify reuqests from the Rocket.Chat server
+    pub rocketchat_token: Option<String>,
+}
+
+impl RocketchatServer {
+    /// Insert or update a `RocketchatServer`.
+    pub fn upsert(connection: &SqliteConnection, new_rocketchat_server: &NewRocketchatServer) -> Result<RocketchatServer> {
+        match RocketchatServer::find_by_url(connection, new_rocketchat_server.rocketchat_url.clone())? {
+            Some(rocketchat_server) => {
+                diesel::update(rocketchat_servers::table.find(rocketchat_server.id)).set(rocketchat_servers::rocketchat_token.eq::<Option<String>>(new_rocketchat_server.rocketchat_token.clone())).execute(connection).chain_err(|| ErrorKind::DBUpdateError)?;
+            }
+            None => {
+                diesel::insert(new_rocketchat_server).into(rocketchat_servers::table)
+                    .execute(connection)
+                    .chain_err(|| ErrorKind::DBInsertError)?;
+            }
+        }
+
+        let rocketchat_server = RocketchatServer::find_by_url(connection, new_rocketchat_server.rocketchat_url.clone())
+            ?
+            .expect("The Rocket.Chat server is always there, because we just inserted it.");
+        Ok(rocketchat_server)
+    }
+
+    /// Find a `RocketchatServer` by its URL.
+    pub fn find_by_url(connection: &SqliteConnection, url: String) -> Result<Option<RocketchatServer>> {
+        let rocketchat_servers = rocketchat_servers::table.filter(rocketchat_servers::rocketchat_url.eq(url))
+            .load(connection)
+            .chain_err(|| ErrorKind::DBSelectError)?;
+        Ok(rocketchat_servers.into_iter().next())
+    }
+
+    /// Find a `RocketchatServer` bit its token.
+    pub fn find_by_token(connection: &SqliteConnection, token: String) -> Result<Option<RocketchatServer>> {
+        let rocketchat_servers = rocketchat_servers::table.filter(rocketchat_servers::rocketchat_token.eq(Some(token)))
+            .load(connection)
+            .chain_err(|| ErrorKind::DBSelectError)?;
+        Ok(rocketchat_servers.into_iter().next())
+    }
+}

--- a/src/matrix-rocketchat/db/room.rs
+++ b/src/matrix-rocketchat/db/room.rs
@@ -18,7 +18,9 @@ pub struct Room {
     pub matrix_room_id: RoomId,
     /// The rooms display name.
     pub display_name: String,
-    /// The rooms unique id on the rocketchat server.
+    /// The Rocket.Chat server the room is connected to.
+    pub rocketchat_server_id: Option<i32>,
+    /// The rooms unique id on the Rocket.Chat server.
     pub rocketchat_room_id: Option<String>,
     /// A flag that indicates if the rooms is used as a admin room for the
     /// Rocket.Chat application service
@@ -57,14 +59,18 @@ impl Room {
 
     /// Find a `Room` by its matrix room ID. Returns an error if the room is not found.
     pub fn find(connection: &SqliteConnection, matrix_room_id: &RoomId) -> Result<Room> {
-        let room = rooms::table.find(matrix_room_id).first(connection).chain_err(|| ErrorKind::DBSelectError)?;
-        Ok(room)
+        rooms::table.find(matrix_room_id).first(connection).chain_err(|| ErrorKind::DBSelectError)
     }
 
     /// Find a `Room` by its matrix room ID. Returns `None`, if the room is not found.
     pub fn find_by_matrix_room_id(connection: &SqliteConnection, matrix_room_id: &RoomId) -> Result<Option<Room>> {
         let rooms = rooms::table.find(matrix_room_id).load(connection).chain_err(|| ErrorKind::DBSelectError)?;
         Ok(rooms.into_iter().next())
+    }
+
+    /// Indicate if the room is connected to a Rocket.Chat server
+    pub fn is_connected(&self) -> bool {
+        self.rocketchat_server_id.is_some()
     }
 
     /// Returns all `User`s in the room.

--- a/src/matrix-rocketchat/db/room.rs
+++ b/src/matrix-rocketchat/db/room.rs
@@ -68,6 +68,14 @@ impl Room {
         Ok(rooms.into_iter().next())
     }
 
+    /// Set the Rocket.Chat id for a room.
+    pub fn set_rocketchat_server_id(&self, connection: &SqliteConnection, rocketchat_server_id: i32) -> Result<()> {
+        diesel::update(rooms::table.find(&self.matrix_room_id)).set(rooms::rocketchat_server_id.eq(rocketchat_server_id))
+            .execute(connection)
+            .chain_err(|| ErrorKind::DBUpdateError)?;
+        Ok(())
+    }
+
     /// Indicate if the room is connected to a Rocket.Chat server
     pub fn is_connected(&self) -> bool {
         self.rocketchat_server_id.is_some()

--- a/src/matrix-rocketchat/db/schema.rs
+++ b/src/matrix-rocketchat/db/schema.rs
@@ -3,6 +3,8 @@
 table! {
     users (matrix_user_id) {
         matrix_user_id -> Text,
+        rocketchat_user_id -> Nullable<Text>,
+        display_name -> Text,
         language -> Text,
         is_virtual_user -> Bool,
         last_message_sent -> BigInt,
@@ -15,6 +17,7 @@ table! {
     rooms (matrix_room_id) {
         matrix_room_id -> Text,
         display_name -> Text,
+        rocketchat_server_id -> Nullable<Integer>,
         rocketchat_room_id -> Nullable<Text>,
         is_admin_room -> Bool,
         is_bridged -> Bool,
@@ -27,6 +30,26 @@ table! {
     users_in_rooms (matrix_user_id, matrix_room_id) {
         matrix_user_id -> Text,
         matrix_room_id -> Text,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+table! {
+    rocketchat_servers (id) {
+        id -> Integer,
+        rocketchat_url -> Text,
+        rocketchat_token -> Nullable<Text>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+table! {
+    users_on_rocketchat_servers (matrix_user_id, rocketchat_server_id) {
+        matrix_user_id -> Text,
+        rocketchat_server_id -> Integer,
+        rocketchat_auth_token -> Nullable<Text>,
         created_at -> Timestamp,
         updated_at -> Timestamp,
     }

--- a/src/matrix-rocketchat/db/user.rs
+++ b/src/matrix-rocketchat/db/user.rs
@@ -12,6 +12,10 @@ use super::schema::users;
 pub struct User {
     /// The users unique id on the Matrix server.
     pub matrix_user_id: UserId,
+    /// The users unique id on the Rocket.Chat server.
+    pub rocketchat_user_id: Option<String>,
+    /// The name that is shown when the user posts messages on Matrix and Rocket.Chat.
+    pub display_name: String,
     /// The language the user prefers to get messages in.
     pub language: String,
     /// Flag to indicate if the user is only used to send messages from Rocket.Chat
@@ -30,6 +34,10 @@ pub struct User {
 pub struct NewUser<'a> {
     /// The users unique id on the Matrix server.
     pub matrix_user_id: UserId,
+    /// The users unique id on the Rocket.Chat server.
+    pub rocketchat_user_id: Option<String>,
+    /// The name that is shown when the user posts messages on Matrix and Rocket.Chat.
+    pub display_name: String,
     /// The language the user prefers to get messages in.
     pub language: &'a str,
     /// Flag to indicate if the user is only used to send messages from Rocket.Chat
@@ -45,8 +53,7 @@ impl User {
 
     /// Find a `User` by his matrix user ID, return an error if the user is not found
     pub fn find(connection: &SqliteConnection, matrix_user_id: &UserId) -> Result<User> {
-        let user = users::table.find(matrix_user_id).first(connection).chain_err(|| ErrorKind::DBSelectError)?;
-        Ok(user)
+        users::table.find(matrix_user_id).first(connection).chain_err(|| ErrorKind::DBSelectError)
     }
 
     /// Find or create `User` with a given Matrix user ID.
@@ -55,7 +62,9 @@ impl User {
             Some(user) => Ok(user),
             None => {
                 let new_user = NewUser {
-                    matrix_user_id: matrix_user_id,
+                    matrix_user_id: matrix_user_id.clone(),
+                    rocketchat_user_id: None,
+                    display_name: matrix_user_id.to_string(),
                     language: DEFAULT_LANGUAGE,
                     is_virtual_user: false,
                 };

--- a/src/matrix-rocketchat/db/user_on_rocketchat_server.rs
+++ b/src/matrix-rocketchat/db/user_on_rocketchat_server.rs
@@ -1,0 +1,59 @@
+use diesel;
+use diesel::prelude::*;
+use diesel::sqlite::SqliteConnection;
+use ruma_identifiers::UserId;
+
+use errors::*;
+use super::schema::users_on_rocketchat_servers;
+
+/// A user on a Rocket.Chat server.
+#[derive(Debug, Queryable)]
+pub struct UserOnRocketchatServer {
+    /// The users unique id on the Rocket.Chat server.
+    pub matrix_user_id: UserId,
+    /// The unique id for the Rocket.Chat server
+    pub rocketchat_server_id: i32,
+    /// The token to identify reuqests from the Rocket.Chat server
+    pub rocketchat_auth_token: Option<String>,
+    /// created timestamp
+    pub created_at: String,
+    /// updated timestamp
+    pub updated_at: String,
+}
+
+/// A new `Room`, not yet saved.
+#[derive(Insertable)]
+#[table_name="users_on_rocketchat_servers"]
+pub struct NewUserOnRocketchatServer {
+    /// The users unique id on the Rocket.Chat server.
+    pub matrix_user_id: UserId,
+    /// The unique id for the Rocket.Chat server
+    pub rocketchat_server_id: i32,
+    /// The token to identify reuqests from the Rocket.Chat server
+    pub rocketchat_auth_token: Option<String>,
+}
+
+impl UserOnRocketchatServer {
+    /// Insert a new `UserOnRocketchatServer` into the database.
+    pub fn insert(connection: &SqliteConnection,
+                  user_on_rocketchat_server: &NewUserOnRocketchatServer)
+                  -> Result<UserOnRocketchatServer> {
+        diesel::insert(user_on_rocketchat_server).into(users_on_rocketchat_servers::table)
+            .execute(connection)
+            .chain_err(|| ErrorKind::DBInsertError)?;
+        UserOnRocketchatServer::find(connection,
+                                     &user_on_rocketchat_server.matrix_user_id,
+                                     user_on_rocketchat_server.rocketchat_server_id)
+    }
+
+    /// Find a `UserOnRocketchatServer` by his matrix user ID and the Rocket.Chat server ID, return
+    /// an error if the `UserOnRocketchatServer` is not found
+    pub fn find(connection: &SqliteConnection,
+                matrix_user_id: &UserId,
+                rocketchat_server_id: i32)
+                -> Result<UserOnRocketchatServer> {
+        users_on_rocketchat_servers::table.find((matrix_user_id, rocketchat_server_id))
+            .first(connection)
+            .chain_err(|| ErrorKind::DBSelectError)
+    }
+}

--- a/src/matrix-rocketchat/errors.rs
+++ b/src/matrix-rocketchat/errors.rs
@@ -112,9 +112,9 @@ error_chain!{
             display("A token is needed to connect new Rocket.Chat servers")
         }
 
-        RocketchatServerAlreadyConnected{
-            description("The Rocket.Chat server is already connected")
-            display("The Rocket.Chat server is already connected")
+        RocketchatServerAlreadyConnected(rocketchat_url: String){
+            description("This Rocket.Chat server is already connected")
+            display("The Rocket.Chat server {} is already connected, connect without a token if you want to connect to the server", rocketchat_url)
         }
 
         RocketchatTokenAlreadyInUse(token: String){

--- a/src/matrix-rocketchat/errors.rs
+++ b/src/matrix-rocketchat/errors.rs
@@ -21,6 +21,15 @@ pub struct MatrixErrorResponse {
     pub error: String,
 }
 
+/// Response from the Rocket.Chat server when an error occurred
+#[derive(Deserialize, Serialize)]
+pub struct RocketchatErrorResponse {
+    /// Status returned by the Rocket.Chat API
+    pub status: String,
+    /// Error message returned by the Rocket.Chat API
+    pub message: String,
+}
+
 error_chain!{
     errors {
         InvalidAccessToken(token: String) {
@@ -68,74 +77,109 @@ error_chain!{
             display("No supported API version found for the Matrix homeserver, found versions: {}", versions)
         }
 
-        ReadFileError(path: String){
+        RocketchatError(error_msg: String) {
+            description("An error occurred when calling the Rocket.Chat API")
+            display("Rocket.Chat error: {}", error_msg)
+        }
+
+        UnsupportedRocketchatApiVersion(versions: String) {
+            description("None of the Rocket.Chat API versions are supported")
+                display("No supported API version found for the Rocket.Chat REST API, found versions: {}", versions)
+        }
+
+        ReadFileError(path: String) {
             description("Reading file failed")
-            display("Reading file from {} failed", path)
+                display("Reading file from {} failed", path)
+        }
+
+        RoomAlreadyConnected(matrix_room_id: String) {
+            description("The Room is already connected to a Rocket.Chat server")
+                display("Room {} is already connected", matrix_room_id)
+        }
+
+        RocketchatTokenMissing{
+            description("A token is needed to connect new Rocket.Chat servers")
+                display("A token is needed to connect new Rocket.Chat servers")
+        }
+
+        RocketchatServerAlreadyConnected{
+            description("The Rocket.Chat server is already connected")
+                display("The Rocket.Chat server is already connected")
+        }
+
+        RocketchatTokenAlreadyInUse(token: String){
+            description("The token is already in use, please use a different token to connect your server")
+                display("The token {} is already in use.", token)
         }
 
         ReadConfigError{
             description("Could not read config content to string")
-            display("Could not read config content to string")
+                display("Could not read config content to string")
         }
 
         ServerStartupError{
             description("Starting the application service failed")
-            display("Starting the application service failed")
+                display("Starting the application service failed")
         }
 
         DatabaseSetupError{
             description("Setting up database failed")
-            display("Setting up database failed")
+                display("Setting up database failed")
         }
 
         MigrationError{
             description("Could not run migrations")
-            display("Could not run migrations")
+                display("Could not run migrations")
         }
 
         DBConnectionError{
             description("Could not establish database connection")
-            display("Could not establish database connection")
+                display("Could not establish database connection")
         }
 
         LoggerExtractionError{
             description("Getting logger from iron request failed")
-            display("Getting logger from iron request failed")
+                display("Getting logger from iron request failed")
         }
 
         ConnectionPoolExtractionError{
             description("Getting connection pool from iron request failed")
-            display("Getting connection pool from iron request failed")
+                display("Getting connection pool from iron request failed")
         }
 
         ConnectionPoolCreationError{
             description("Could not create connection pool")
-            display("Could not create connection pool")
+                display("Could not create connection pool")
         }
 
         GetConnectionError{
             description("Getting connection from connection pool failed")
-            display("Getting connection from connection pool failed")
+                display("Getting connection from connection pool failed")
         }
 
         DBInsertError {
             description("Inserting record into the database failed")
-            display("Inserting record into the database failed")
+                display("Inserting record into the database failed")
+        }
+
+        DBUpdateError{
+            description("Editing record in database failed")
+                display("Editing record in the database failed")
         }
 
         DBSelectError{
             description("Select record from the database failed")
-            display("Select record from the database failed")
+                display("Select record from the database failed")
         }
 
         DBDeleteError{
             description("Deleting record from the database failed")
-            display("Deleting record from the database failed")
+                display("Deleting record from the database failed")
         }
 
         InternalServerError {
             description("An internal error occurred")
-            display("An internal error occurred")
+                display("An internal error occurred")
         }
     }
 }

--- a/src/matrix-rocketchat/errors.rs
+++ b/src/matrix-rocketchat/errors.rs
@@ -84,7 +84,7 @@ error_chain!{
 
         NoRocketchatServer(url: String){
             description("No Rockat.Chat server found.")
-            display("No Rocket.Chat server found when querying {}", url)
+            display("No Rocket.Chat server found when querying {} (version information is missing from the response)", url)
         }
 
         RocketchatServerUnreachable(url: String) {
@@ -92,9 +92,9 @@ error_chain!{
             display("Could not reach Rocket.Chat server {}", url)
         }
 
-        UnsupportedRocketchatApiVersion(versions: String) {
+        UnsupportedRocketchatApiVersion(min_version: String, versions: String) {
             description("None of the Rocket.Chat API versions are supported")
-            display("No supported API version found for the Rocket.Chat REST API, found versions: {}", versions)
+            display("No supported API version (>= {}) found for the Rocket.Chat server, found version: {}", min_version, versions)
         }
 
         ReadFileError(path: String) {

--- a/src/matrix-rocketchat/errors.rs
+++ b/src/matrix-rocketchat/errors.rs
@@ -82,104 +82,114 @@ error_chain!{
             display("Rocket.Chat error: {}", error_msg)
         }
 
+        NoRocketchatServer(url: String){
+            description("No Rockat.Chat server found.")
+            display("No Rocket.Chat server found when querying {}", url)
+        }
+
+        RocketchatServerUnreachable(url: String) {
+            description("Rocket.Chat server unreachable")
+            display("Could not reach Rocket.Chat server {}", url)
+        }
+
         UnsupportedRocketchatApiVersion(versions: String) {
             description("None of the Rocket.Chat API versions are supported")
-                display("No supported API version found for the Rocket.Chat REST API, found versions: {}", versions)
+            display("No supported API version found for the Rocket.Chat REST API, found versions: {}", versions)
         }
 
         ReadFileError(path: String) {
             description("Reading file failed")
-                display("Reading file from {} failed", path)
+            display("Reading file from {} failed", path)
         }
 
         RoomAlreadyConnected(matrix_room_id: String) {
             description("The Room is already connected to a Rocket.Chat server")
-                display("Room {} is already connected", matrix_room_id)
+            display("Room {} is already connected", matrix_room_id)
         }
 
         RocketchatTokenMissing{
             description("A token is needed to connect new Rocket.Chat servers")
-                display("A token is needed to connect new Rocket.Chat servers")
+            display("A token is needed to connect new Rocket.Chat servers")
         }
 
         RocketchatServerAlreadyConnected{
             description("The Rocket.Chat server is already connected")
-                display("The Rocket.Chat server is already connected")
+            display("The Rocket.Chat server is already connected")
         }
 
         RocketchatTokenAlreadyInUse(token: String){
             description("The token is already in use, please use a different token to connect your server")
-                display("The token {} is already in use.", token)
+            display("The token {} is already in use.", token)
         }
 
         ReadConfigError{
             description("Could not read config content to string")
-                display("Could not read config content to string")
+            display("Could not read config content to string")
         }
 
         ServerStartupError{
             description("Starting the application service failed")
-                display("Starting the application service failed")
+            display("Starting the application service failed")
         }
 
         DatabaseSetupError{
             description("Setting up database failed")
-                display("Setting up database failed")
+            display("Setting up database failed")
         }
 
         MigrationError{
             description("Could not run migrations")
-                display("Could not run migrations")
+            display("Could not run migrations")
         }
 
         DBConnectionError{
             description("Could not establish database connection")
-                display("Could not establish database connection")
+            display("Could not establish database connection")
         }
 
         LoggerExtractionError{
             description("Getting logger from iron request failed")
-                display("Getting logger from iron request failed")
+            display("Getting logger from iron request failed")
         }
 
         ConnectionPoolExtractionError{
             description("Getting connection pool from iron request failed")
-                display("Getting connection pool from iron request failed")
+            display("Getting connection pool from iron request failed")
         }
 
         ConnectionPoolCreationError{
             description("Could not create connection pool")
-                display("Could not create connection pool")
+            display("Could not create connection pool")
         }
 
         GetConnectionError{
             description("Getting connection from connection pool failed")
-                display("Getting connection from connection pool failed")
+            display("Getting connection from connection pool failed")
         }
 
         DBInsertError {
             description("Inserting record into the database failed")
-                display("Inserting record into the database failed")
+            display("Inserting record into the database failed")
         }
 
         DBUpdateError{
             description("Editing record in database failed")
-                display("Editing record in the database failed")
+            display("Editing record in the database failed")
         }
 
         DBSelectError{
             description("Select record from the database failed")
-                display("Select record from the database failed")
+            display("Select record from the database failed")
         }
 
         DBDeleteError{
             description("Deleting record from the database failed")
-                display("Deleting record from the database failed")
+            display("Deleting record from the database failed")
         }
 
         InternalServerError {
             description("An internal error occurred")
-                display("An internal error occurred")
+            display("An internal error occurred")
         }
     }
 }

--- a/src/matrix-rocketchat/errors.rs
+++ b/src/matrix-rocketchat/errors.rs
@@ -119,7 +119,7 @@ error_chain!{
 
         RocketchatTokenAlreadyInUse(token: String){
             description("The token is already in use, please use a different token to connect your server")
-            display("The token {} is already in use.", token)
+            display("The token {} is already in use, please use another token.", token)
         }
 
         ReadConfigError{

--- a/src/matrix-rocketchat/handlers/events/command_handler.rs
+++ b/src/matrix-rocketchat/handlers/events/command_handler.rs
@@ -71,7 +71,7 @@ impl<'a> CommandHandler<'a> {
 
         debug!(self.logger, "Attempting to connect to Rocket.Chat server {}", rocketchat_url);
 
-        let rocketchat_server = match command.by_ref().next() {
+        match command.by_ref().next() {
             Some(token) => self.connect_new_server(rocketchat_url.to_string(), token.to_string(), &event.user_id)?,
             None => self.connect_existing_server(rocketchat_url.to_string(), &event.user_id)?,
         };
@@ -86,11 +86,7 @@ impl<'a> CommandHandler<'a> {
         Ok(())
     }
 
-    fn connect_new_server(&self,
-                          rocketchat_url: String,
-                          token: String,
-                          matrix_user_id: &UserId)
-                          -> Result<RocketchatServer> {
+    fn connect_new_server(&self, rocketchat_url: String, token: String, matrix_user_id: &UserId) -> Result<()> {
         if let Some(rocketchat_server) = RocketchatServer::find_by_url(self.connection, rocketchat_url.clone())? {
             if rocketchat_server.rocketchat_token.is_some() {
                 bail!(ErrorKind::RocketchatServerAlreadyConnected);
@@ -119,12 +115,12 @@ impl<'a> CommandHandler<'a> {
 
         UserOnRocketchatServer::insert(self.connection, &new_user_on_rocketchat_server)?;
 
-        Ok(rocketchat_server)
+        Ok(())
     }
 
-    fn connect_existing_server(&self, rocketchat_url: String, user_id: &UserId) -> Result<RocketchatServer> {
-        let rocketchat_server = match RocketchatServer::find_by_url(self.connection, rocketchat_url)? {
-            Some(rocketchat_server) => Ok(rocketchat_server),
+    fn connect_existing_server(&self, rocketchat_url: String, user_id: &UserId) -> Result<()> {
+        let rocketchat_server: RocketchatServer = match RocketchatServer::find_by_url(self.connection, rocketchat_url)? {
+            Some(rocketchat_server) => rocketchat_server,
             None => {
                 bail!(ErrorKind::RocketchatTokenMissing);
             }
@@ -132,6 +128,6 @@ impl<'a> CommandHandler<'a> {
 
         // TODO: Add UserOnRocketchatServer with the connecting user
 
-        rocketchat_server
+        Ok(())
     }
 }

--- a/src/matrix-rocketchat/handlers/events/command_handler.rs
+++ b/src/matrix-rocketchat/handlers/events/command_handler.rs
@@ -111,7 +111,7 @@ impl<'a> CommandHandler<'a> {
             rocketchat_token: Some(token),
         };
 
-        RocketchatServer::upsert(self.connection, &new_rocketchat_server)
+        RocketchatServer::insert(self.connection, &new_rocketchat_server)
     }
 
     fn get_existing_rocketchat_server(&self, rocketchat_url: String) -> Result<RocketchatServer> {

--- a/src/matrix-rocketchat/handlers/events/command_handler.rs
+++ b/src/matrix-rocketchat/handlers/events/command_handler.rs
@@ -40,8 +40,7 @@ impl<'a> CommandHandler<'a> {
         let message = match event.content {
             MessageEventContent::Text(ref text_content) => text_content.body.clone(),
             _ => {
-                let msg = format!("Unknown event content type, message type is {}, skipping", event.event_type);
-                debug!(self.logger, msg);
+                debug!(self.logger, "Unknown event content type, skipping");
                 return Ok(());
             }
         };

--- a/src/matrix-rocketchat/handlers/events/command_handler.rs
+++ b/src/matrix-rocketchat/handlers/events/command_handler.rs
@@ -1,0 +1,137 @@
+use std::collections::HashMap;
+
+use diesel::sqlite::SqliteConnection;
+use ruma_events::room::message::MessageEvent;
+use ruma_events::room::message::MessageEventContent;
+use ruma_identifiers::UserId;
+use slog::Logger;
+
+use api::{MatrixApi, RocketchatApi};
+use config::Config;
+use db::{NewRocketchatServer, NewUserOnRocketchatServer, RocketchatServer, Room, User, UserOnRocketchatServer};
+use errors::*;
+use i18n::*;
+
+/// Handles command messages from the admin room
+pub struct CommandHandler<'a> {
+    config: &'a Config,
+    connection: &'a SqliteConnection,
+    logger: Logger,
+    matrix_api: Box<MatrixApi>,
+}
+
+impl<'a> CommandHandler<'a> {
+    /// Create a new `CommandHandler`.
+    pub fn new(config: &'a Config,
+               connection: &'a SqliteConnection,
+               logger: Logger,
+               matrix_api: Box<MatrixApi>)
+               -> CommandHandler<'a> {
+        CommandHandler {
+            config: config,
+            connection: connection,
+            logger: logger,
+            matrix_api: matrix_api,
+        }
+    }
+
+    /// Handles command messages from an admin room
+    pub fn process(&self, event: &MessageEvent) -> Result<()> {
+        let message = match event.content {
+            MessageEventContent::Text(ref text_content) => text_content.body.clone(),
+            _ => {
+                let msg = format!("Unknown event content type, message type is {}, skipping", event.event_type);
+                debug!(self.logger, msg);
+                return Ok(());
+            }
+        };
+
+        if message.starts_with("connect") {
+            let msg = format!("Received connect command: {}", message);
+            debug!(self.logger, msg);
+
+            self.handle_connect(&event, &message)?;
+        } else {
+            let msg = format!("Skipping event, don't know how to handle command `{}`", message);
+            debug!(self.logger, msg);
+        }
+
+        Ok(())
+    }
+
+    fn handle_connect(&self, event: &MessageEvent, message: &str) -> Result<()> {
+        if let Some(room) = Room::find_by_matrix_room_id(self.connection, &event.room_id)? {
+            if room.is_connected() {
+                bail!(ErrorKind::RoomAlreadyConnected(event.room_id.to_string()));
+            }
+        }
+
+        let mut command = message.split_whitespace().collect::<Vec<&str>>().into_iter();
+        let rocketchat_url = command.by_ref().skip(1).next().unwrap_or_default();
+
+        debug!(self.logger, "Attempting to connect to Rocket.Chat server {}", rocketchat_url);
+
+        let rocketchat_server = match command.by_ref().next() {
+            Some(token) => self.connect_new_server(rocketchat_url.to_string(), token.to_string(), &event.user_id)?,
+            None => self.connect_existing_server(rocketchat_url.to_string(), &event.user_id)?,
+        };
+
+        debug!(self.logger, "User is: {}", event.user_id);
+        let user = User::find(self.connection, &event.user_id)?;
+        let mut vars = HashMap::new();
+        vars.insert("rocketchat_url", rocketchat_url.as_ref());
+        let body = t!(["admin_command", "successfully_connected"]).l(&user.language, Some(vars));
+        self.matrix_api.send_text_message_event(event.room_id.clone(), self.config.matrix_bot_user_id()?, body)?;
+
+        Ok(())
+    }
+
+    fn connect_new_server(&self,
+                          rocketchat_url: String,
+                          token: String,
+                          matrix_user_id: &UserId)
+                          -> Result<RocketchatServer> {
+        if let Some(rocketchat_server) = RocketchatServer::find_by_url(self.connection, rocketchat_url.clone())? {
+            if rocketchat_server.rocketchat_token.is_some() {
+                bail!(ErrorKind::RocketchatServerAlreadyConnected);
+            }
+        }
+
+        if RocketchatServer::find_by_token(self.connection, token.clone())?.is_some() {
+            bail!(ErrorKind::RocketchatTokenAlreadyInUse(token));
+        }
+
+        // see if we can reach the server and if the server has a supported API version
+        RocketchatApi::new(rocketchat_url.clone(), Some(token.clone()), self.logger.clone())?;
+
+        let new_rocketchat_server = NewRocketchatServer {
+            rocketchat_url: rocketchat_url,
+            rocketchat_token: Some(token),
+        };
+
+        let rocketchat_server = RocketchatServer::upsert(self.connection, &new_rocketchat_server)?;
+
+        let new_user_on_rocketchat_server = NewUserOnRocketchatServer {
+            matrix_user_id: matrix_user_id.clone(),
+            rocketchat_server_id: rocketchat_server.id,
+            rocketchat_auth_token: None,
+        };
+
+        UserOnRocketchatServer::insert(self.connection, &new_user_on_rocketchat_server)?;
+
+        Ok(rocketchat_server)
+    }
+
+    fn connect_existing_server(&self, rocketchat_url: String, user_id: &UserId) -> Result<RocketchatServer> {
+        let rocketchat_server = match RocketchatServer::find_by_url(self.connection, rocketchat_url)? {
+            Some(rocketchat_server) => Ok(rocketchat_server),
+            None => {
+                bail!(ErrorKind::RocketchatTokenMissing);
+            }
+        };
+
+        // TODO: Add UserOnRocketchatServer with the connecting user
+
+        rocketchat_server
+    }
+}

--- a/src/matrix-rocketchat/handlers/events/mod.rs
+++ b/src/matrix-rocketchat/handlers/events/mod.rs
@@ -1,9 +1,12 @@
 //! Event handlers
 
+/// Handles commands from the admin room
+pub mod command_handler;
 /// Event dispatcher
 pub mod event_dispatcher;
 /// Handles room events
 pub mod room_handler;
 
+pub use self::command_handler::CommandHandler;
 pub use self::event_dispatcher::EventDispatcher;
 pub use self::room_handler::RoomHandler;

--- a/src/matrix-rocketchat/server.rs
+++ b/src/matrix-rocketchat/server.rs
@@ -9,8 +9,7 @@ use slog::Logger;
 
 use api::MatrixApi;
 use config::Config;
-use db::ConnectionPool;
-use db::user::{NewUser, User};
+use db::{ConnectionPool, NewUser, User};
 use errors::*;
 use handlers::iron::{Transactions, Welcome};
 use i18n::*;
@@ -83,6 +82,8 @@ impl<'a> Server<'a> {
                 matrix_api.register(self.config.sender_localpart.clone())?;
                 let new_user = NewUser {
                     matrix_user_id: matrix_bot_user_id.clone(),
+                    rocketchat_user_id: None,
+                    display_name: matrix_bot_user_id.to_string(),
                     language: DEFAULT_LANGUAGE,
                     is_virtual_user: false,
                 };

--- a/tests/admin_commands.rs
+++ b/tests/admin_commands.rs
@@ -1,5 +1,6 @@
 #![feature(try_from)]
 
+extern crate iron;
 extern crate matrix_rocketchat;
 extern crate matrix_rocketchat_test;
 extern crate router;
@@ -7,9 +8,13 @@ extern crate ruma_client_api;
 extern crate ruma_identifiers;
 
 use std::convert::TryFrom;
+use std::sync::mpsc::channel;
+use std::thread;
 
+use iron::{Iron, Listening, status};
 use matrix_rocketchat::db::{RocketchatServer, UserOnRocketchatServer};
-use matrix_rocketchat_test::{MessageForwarder, Test, default_timeout, helpers};
+use matrix_rocketchat_test::{IRON_THREADS, MessageForwarder, Test, default_timeout, get_free_socket_addr, handlers,
+                             helpers};
 use router::Router;
 use ruma_client_api::Endpoint;
 use ruma_client_api::r0::send::send_message_event::Endpoint as SendMessageEventEndpoint;
@@ -45,10 +50,149 @@ fn successfully_connect_rocketchat_server() {
 }
 
 #[test]
-fn connect_to_incompatible_rocketchat_server_version() {}
+fn attempt_to_connect_to_an_incompatible_rocketchat_server_version() {
+    let (message_forwarder, receiver) = MessageForwarder::new();
+    let mut matrix_router = Router::new();
+    matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
+
+    let (tx, rx) = channel::<Listening>();
+    let socket_addr = get_free_socket_addr();
+
+    thread::spawn(move || {
+        let mut rocketchat_router = Router::new();
+        rocketchat_router.get("/api/info", handlers::RocketchatInfo { version: "0.1.0" }, "info");
+        let mut server = Iron::new(rocketchat_router);
+        server.threads = IRON_THREADS;
+        let listening = server.http(&socket_addr).unwrap();
+        tx.send(listening).unwrap();
+    });
+    let mut listening = rx.recv_timeout(default_timeout() * 2).unwrap();
+    let rocketchat_mock_url = format!("http://{}", socket_addr);
+
+    let test = Test::new()
+        .with_custom_matrix_routes(matrix_router)
+        .with_rocketchat_mock()
+        .with_admin_room()
+        .run();
+
+    helpers::send_room_message_from_matrix(&test.config.as_url,
+                                           RoomId::try_from("!admin:localhost").unwrap(),
+                                           UserId::try_from("@spec_user:localhost").unwrap(),
+                                           format!("connect {} spec_token", rocketchat_mock_url.clone()));
+
+    listening.close().unwrap();
+
+    // discard welcome message
+    receiver.recv_timeout(default_timeout()).unwrap();
+
+    let message_received_by_matrix = receiver.recv_timeout(default_timeout()).unwrap();
+    assert!(message_received_by_matrix.contains("No supported API version found for the Rocket.Chat REST API, found versions: 0.1.0"));
+}
 
 #[test]
-fn attempt_to_create_to_non_rocketchat_server() {}
+fn attempt_to_connect_to_a_non_rocketchat_server() {
+    let (message_forwarder, receiver) = MessageForwarder::new();
+    let mut matrix_router = Router::new();
+    matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
+
+    let (tx, rx) = channel::<Listening>();
+    let socket_addr = get_free_socket_addr();
+
+    thread::spawn(move || {
+        let rocketchat_router = Router::new();
+        let mut server = Iron::new(rocketchat_router);
+        server.threads = IRON_THREADS;
+        let listening = server.http(&socket_addr).unwrap();
+        tx.send(listening).unwrap();
+    });
+    let mut listening = rx.recv_timeout(default_timeout() * 2).unwrap();
+    let rocketchat_mock_url = format!("http://{}", socket_addr);
+
+    let test = Test::new()
+        .with_custom_matrix_routes(matrix_router)
+        .with_rocketchat_mock()
+        .with_admin_room()
+        .run();
+
+    helpers::send_room_message_from_matrix(&test.config.as_url,
+                                           RoomId::try_from("!admin:localhost").unwrap(),
+                                           UserId::try_from("@spec_user:localhost").unwrap(),
+                                           format!("connect {} spec_token", rocketchat_mock_url.clone()));
+
+    listening.close().unwrap();
+
+    // discard welcome message
+    receiver.recv_timeout(default_timeout()).unwrap();
+
+    let message_received_by_matrix = receiver.recv_timeout(default_timeout()).unwrap();
+    assert!(message_received_by_matrix.contains(&format!("No Rocket.Chat server found when querying {}", rocketchat_mock_url)));
+}
 
 #[test]
-fn attempt_to_connect_to_non_existing_server() {}
+fn attempt_to_connect_to_a_server_with_the_correct_endpoint_but_an_incompatible_response() {
+    let (message_forwarder, receiver) = MessageForwarder::new();
+    let mut matrix_router = Router::new();
+    matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
+
+    let (tx, rx) = channel::<Listening>();
+    let socket_addr = get_free_socket_addr();
+
+    thread::spawn(move || {
+        let mut rocketchat_router = Router::new();
+        rocketchat_router.get("/api/info", handlers::InvalidJsonResponse { status: status::Ok }, "info");
+        let mut server = Iron::new(rocketchat_router);
+        server.threads = IRON_THREADS;
+        let listening = server.http(&socket_addr).unwrap();
+        tx.send(listening).unwrap();
+    });
+    let mut listening = rx.recv_timeout(default_timeout() * 2).unwrap();
+    let rocketchat_mock_url = format!("http://{}", socket_addr);
+
+    let test = Test::new()
+        .with_custom_matrix_routes(matrix_router)
+        .with_rocketchat_mock()
+        .with_admin_room()
+        .run();
+
+    helpers::send_room_message_from_matrix(&test.config.as_url,
+                                           RoomId::try_from("!admin:localhost").unwrap(),
+                                           UserId::try_from("@spec_user:localhost").unwrap(),
+                                           format!("connect {} spec_token", rocketchat_mock_url.clone()));
+
+    listening.close().unwrap();
+
+    // discard welcome message
+    receiver.recv_timeout(default_timeout()).unwrap();
+
+    let message_received_by_matrix = receiver.recv_timeout(default_timeout()).unwrap();
+    assert!(message_received_by_matrix.contains(&format!("No Rocket.Chat server found when querying {}", rocketchat_mock_url)));
+}
+
+
+#[test]
+fn attempt_to_connect_to_non_existing_server() {
+    let (message_forwarder, receiver) = MessageForwarder::new();
+    let mut matrix_router = Router::new();
+    matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
+
+    let socket_addr = get_free_socket_addr();
+    let rocketchat_mock_url = format!("http://{}", socket_addr);
+
+    let test = Test::new()
+        .with_custom_matrix_routes(matrix_router)
+        .with_rocketchat_mock()
+        .with_admin_room()
+        .run();
+
+    helpers::send_room_message_from_matrix(&test.config.as_url,
+                                           RoomId::try_from("!admin:localhost").unwrap(),
+                                           UserId::try_from("@spec_user:localhost").unwrap(),
+                                           format!("connect {} spec_token", rocketchat_mock_url.clone()));
+
+    // discard welcome message
+    receiver.recv_timeout(default_timeout()).unwrap();
+
+    let message_received_by_matrix = receiver.recv_timeout(default_timeout()).unwrap();
+    println!("MMM: {}", message_received_by_matrix);
+    assert!(message_received_by_matrix.contains(&format!("Could not reach Rocket.Chat server {}", rocketchat_mock_url)));
+}

--- a/tests/admin_commands.rs
+++ b/tests/admin_commands.rs
@@ -1,0 +1,39 @@
+#![feature(try_from)]
+
+extern crate matrix_rocketchat_test;
+extern crate router;
+extern crate ruma_client_api;
+extern crate ruma_identifiers;
+
+use std::convert::TryFrom;
+
+use matrix_rocketchat_test::{MessageForwarder, Test, default_timeout, helpers};
+use router::Router;
+use ruma_client_api::Endpoint;
+use ruma_client_api::r0::send::send_message_event::Endpoint as SendMessageEventEndpoint;
+use ruma_identifiers::{RoomId, UserId};
+
+#[test]
+fn successfully_connect_rocketchat_server() {
+    let (message_forwarder, receiver) = MessageForwarder::new();
+    let mut matrix_router = Router::new();
+    matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
+    let test = Test::new().with_custom_matrix_routes(matrix_router).with_rocketchat_mock().run();
+
+    helpers::send_room_message_from_matrix(&test.config.as_url,
+                                           RoomId::try_from("!admin:localhost").unwrap(),
+                                           UserId::try_from("@spec_user:localhost").unwrap(),
+                                           format!("connect {} spec_token", test.rocketchat_mock_url.clone().unwrap()));
+
+    let message_received_by_matrix = receiver.recv_timeout(default_timeout()).unwrap();
+    assert!(message_received_by_matrix.contains(&format!("You are connected to {}",test.rocketchat_mock_url.clone().unwrap())));
+}
+
+#[test]
+fn connect_to_incompatible_rocketchat_server_version() {}
+
+#[test]
+fn attempt_to_create_to_non_rocketchat_server() {}
+
+#[test]
+fn attempt_to_connect_to_non_existing_server() {}

--- a/tests/admin_commands.rs
+++ b/tests/admin_commands.rs
@@ -1,5 +1,6 @@
 #![feature(try_from)]
 
+extern crate matrix_rocketchat;
 extern crate matrix_rocketchat_test;
 extern crate router;
 extern crate ruma_client_api;
@@ -7,6 +8,7 @@ extern crate ruma_identifiers;
 
 use std::convert::TryFrom;
 
+use matrix_rocketchat::db::{RocketchatServer, UserOnRocketchatServer};
 use matrix_rocketchat_test::{MessageForwarder, Test, default_timeout, helpers};
 use router::Router;
 use ruma_client_api::Endpoint;
@@ -18,15 +20,28 @@ fn successfully_connect_rocketchat_server() {
     let (message_forwarder, receiver) = MessageForwarder::new();
     let mut matrix_router = Router::new();
     matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).with_rocketchat_mock().run();
+    let test = Test::new().with_custom_matrix_routes(matrix_router).with_rocketchat_mock().with_admin_room().run();
 
     helpers::send_room_message_from_matrix(&test.config.as_url,
                                            RoomId::try_from("!admin:localhost").unwrap(),
                                            UserId::try_from("@spec_user:localhost").unwrap(),
                                            format!("connect {} spec_token", test.rocketchat_mock_url.clone().unwrap()));
 
+    // discard welcome message
+    receiver.recv_timeout(default_timeout()).unwrap();
+
     let message_received_by_matrix = receiver.recv_timeout(default_timeout()).unwrap();
     assert!(message_received_by_matrix.contains(&format!("You are connected to {}",test.rocketchat_mock_url.clone().unwrap())));
+
+    let connection = test.connection_pool.get().unwrap();
+    let rocketchat_server =
+        RocketchatServer::find_by_url(&connection, test.rocketchat_mock_url.clone().unwrap()).unwrap().unwrap();
+    assert_eq!(rocketchat_server.rocketchat_token.unwrap(), "spec_token".to_string());
+
+    let users_on_rocketchat_server = UserOnRocketchatServer::find(&connection,
+                                                                  &UserId::try_from("@spec_user:localhost").unwrap(),
+                                                                  rocketchat_server.id);
+    assert!(users_on_rocketchat_server.is_ok())
 }
 
 #[test]

--- a/tests/admin_commands_connect.rs
+++ b/tests/admin_commands_connect.rs
@@ -81,7 +81,7 @@ fn attempt_to_connect_to_an_incompatible_rocketchat_server_version() {
     receiver.recv_timeout(default_timeout()).unwrap();
 
     let message_received_by_matrix = receiver.recv_timeout(default_timeout()).unwrap();
-    assert!(message_received_by_matrix.contains("No supported API version found for the Rocket.Chat REST API, found versions: 0.1.0"));
+    assert!(message_received_by_matrix.contains("No supported API version (>= 0.49) found for the Rocket.Chat server, found version: 0.1.0"));
 }
 
 #[test]
@@ -160,7 +160,7 @@ fn attempt_to_connect_to_a_server_with_the_correct_endpoint_but_an_incompatible_
     receiver.recv_timeout(default_timeout()).unwrap();
 
     let message_received_by_matrix = receiver.recv_timeout(default_timeout()).unwrap();
-    assert!(message_received_by_matrix.contains(&format!("No Rocket.Chat server found when querying {}", rocketchat_mock_url)));
+    assert!(message_received_by_matrix.contains(&format!("No Rocket.Chat server found when querying {}/api/info (version information is missing from the response)", rocketchat_mock_url)));
 }
 
 

--- a/tests/admin_commands_connect.rs
+++ b/tests/admin_commands_connect.rs
@@ -193,6 +193,17 @@ fn attempt_to_connect_to_non_existing_server() {
     receiver.recv_timeout(default_timeout()).unwrap();
 
     let message_received_by_matrix = receiver.recv_timeout(default_timeout()).unwrap();
-    println!("MMM: {}", message_received_by_matrix);
     assert!(message_received_by_matrix.contains(&format!("Could not reach Rocket.Chat server {}", rocketchat_mock_url)));
 }
+
+#[test]
+fn connect_an_existing_server() {}
+
+#[test]
+fn attempt_to_connect_to_an_existing_server_with_a_token() {}
+
+#[test]
+fn attempt_to_connect_an_already_connected_room() {}
+
+#[test]
+fn attempt_to_connect_a_server_with_a_token_that_is_already_in_use() {}

--- a/tests/admin_commands_connect.rs
+++ b/tests/admin_commands_connect.rs
@@ -25,12 +25,7 @@ fn successfully_connect_rocketchat_server() {
     let (message_forwarder, receiver) = MessageForwarder::new();
     let mut matrix_router = Router::new();
     matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).with_rocketchat_mock().with_admin_room().run();
-
-    helpers::send_room_message_from_matrix(&test.config.as_url,
-                                           RoomId::try_from("!admin:localhost").unwrap(),
-                                           UserId::try_from("@spec_user:localhost").unwrap(),
-                                           format!("connect {} spec_token", test.rocketchat_mock_url.clone().unwrap()));
+    let test = Test::new().with_matrix_routes(matrix_router).with_rocketchat_mock().with_connected_admin_room().run();
 
     // discard welcome message
     receiver.recv_timeout(default_timeout()).unwrap();
@@ -70,7 +65,7 @@ fn attempt_to_connect_to_an_incompatible_rocketchat_server_version() {
     let rocketchat_mock_url = format!("http://{}", socket_addr);
 
     let test = Test::new()
-        .with_custom_matrix_routes(matrix_router)
+        .with_matrix_routes(matrix_router)
         .with_rocketchat_mock()
         .with_admin_room()
         .run();
@@ -109,7 +104,7 @@ fn attempt_to_connect_to_a_non_rocketchat_server() {
     let rocketchat_mock_url = format!("http://{}", socket_addr);
 
     let test = Test::new()
-        .with_custom_matrix_routes(matrix_router)
+        .with_matrix_routes(matrix_router)
         .with_rocketchat_mock()
         .with_admin_room()
         .run();
@@ -149,7 +144,7 @@ fn attempt_to_connect_to_a_server_with_the_correct_endpoint_but_an_incompatible_
     let rocketchat_mock_url = format!("http://{}", socket_addr);
 
     let test = Test::new()
-        .with_custom_matrix_routes(matrix_router)
+        .with_matrix_routes(matrix_router)
         .with_rocketchat_mock()
         .with_admin_room()
         .run();
@@ -179,7 +174,7 @@ fn attempt_to_connect_to_non_existing_server() {
     let rocketchat_mock_url = format!("http://{}", socket_addr);
 
     let test = Test::new()
-        .with_custom_matrix_routes(matrix_router)
+        .with_matrix_routes(matrix_router)
         .with_rocketchat_mock()
         .with_admin_room()
         .run();

--- a/tests/admin_commands_unkown.rs
+++ b/tests/admin_commands_unkown.rs
@@ -7,7 +7,7 @@ extern crate ruma_identifiers;
 
 use std::convert::TryFrom;
 
-use matrix_rocketchat_test::{MessageForwarder, Test, default_timeout, get_free_socket_addr, helpers};
+use matrix_rocketchat_test::{MessageForwarder, Test, default_timeout, helpers};
 use router::Router;
 use ruma_client_api::Endpoint;
 use ruma_client_api::r0::send::send_message_event::Endpoint as SendMessageEventEndpoint;
@@ -21,7 +21,7 @@ fn unknown_commands_from_the_admin_room_are_ignored() {
     matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
 
     let test = Test::new()
-        .with_custom_matrix_routes(matrix_router)
+        .with_matrix_routes(matrix_router)
         .with_admin_room()
         .run();
 
@@ -41,7 +41,7 @@ fn unknown_content_types_from_the_admin_room_are_ignored() {
     matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
 
     let test = Test::new()
-        .with_custom_matrix_routes(matrix_router)
+        .with_matrix_routes(matrix_router)
         .with_admin_room()
         .run();
 

--- a/tests/admin_commands_unkown.rs
+++ b/tests/admin_commands_unkown.rs
@@ -33,3 +33,23 @@ fn unknown_commands_from_the_admin_room_are_ignored() {
     // we don't get a message, because the command is ignored and no error occurs
     receiver.recv_timeout(default_timeout()).is_err();
 }
+
+#[test]
+fn unknown_content_types_from_the_admin_room_are_ignored() {
+    let (message_forwarder, receiver) = MessageForwarder::new();
+    let mut matrix_router = Router::new();
+    matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
+
+    let test = Test::new()
+        .with_custom_matrix_routes(matrix_router)
+        .with_admin_room()
+        .run();
+
+    helpers::send_emote_message_from_matrix(&test.config.as_url,
+                                            RoomId::try_from("!admin:localhost").unwrap(),
+                                            UserId::try_from("@spec_user:localhost").unwrap(),
+                                            "emote message".to_string());
+
+    // we don't get a message, because unkown content types are ignored and no error occurs
+    receiver.recv_timeout(default_timeout()).is_err();
+}

--- a/tests/admin_commands_unkown.rs
+++ b/tests/admin_commands_unkown.rs
@@ -1,0 +1,35 @@
+#![feature(try_from)]
+
+extern crate matrix_rocketchat_test;
+extern crate router;
+extern crate ruma_client_api;
+extern crate ruma_identifiers;
+
+use std::convert::TryFrom;
+
+use matrix_rocketchat_test::{MessageForwarder, Test, default_timeout, get_free_socket_addr, helpers};
+use router::Router;
+use ruma_client_api::Endpoint;
+use ruma_client_api::r0::send::send_message_event::Endpoint as SendMessageEventEndpoint;
+use ruma_identifiers::{RoomId, UserId};
+
+
+#[test]
+fn unknown_commands_from_the_admin_room_are_ignored() {
+    let (message_forwarder, receiver) = MessageForwarder::new();
+    let mut matrix_router = Router::new();
+    matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
+
+    let test = Test::new()
+        .with_custom_matrix_routes(matrix_router)
+        .with_admin_room()
+        .run();
+
+    helpers::send_room_message_from_matrix(&test.config.as_url,
+                                           RoomId::try_from("!admin:localhost").unwrap(),
+                                           UserId::try_from("@spec_user:localhost").unwrap(),
+                                           "bogus command".to_string());
+
+    // we don't get a message, because the command is ignored and no error occurs
+    receiver.recv_timeout(default_timeout()).is_err();
+}

--- a/tests/admin_room.rs
+++ b/tests/admin_room.rs
@@ -43,7 +43,7 @@ fn successfully_create_an_admin_room() {
     };
     matrix_router.get(GetMemberEventsEndpoint::router_path(), room_members, "get_member_events");
     matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).run();
+    let test = Test::new().with_matrix_routes(matrix_router).run();
 
     helpers::create_admin_room(&test.config.as_url,
                                RoomId::try_from("!admin:localhost").unwrap(),
@@ -75,7 +75,7 @@ fn attempt_to_create_an_admin_room_with_other_users_in_it() {
     };
     matrix_router.get(GetMemberEventsEndpoint::router_path(), room_members, "get_member_events");
     matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).run();
+    let test = Test::new().with_matrix_routes(matrix_router).run();
 
     helpers::create_admin_room(&test.config.as_url,
                                RoomId::try_from("!admin:localhost").unwrap(),
@@ -116,7 +116,7 @@ fn bot_leaves_and_forgets_the_room_when_the_user_leaves_it() {
     let mut matrix_router = Router::new();
     matrix_router.post(LeaveRoomEndpoint::router_path(), leave_message_forwarder, "leave_room");
     matrix_router.post(ForgetRoomEndpoint::router_path(), forget_message_forwarder, "forget_room");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).with_admin_room().run();
+    let test = Test::new().with_matrix_routes(matrix_router).with_admin_room().run();
 
     let connection = test.connection_pool.get().unwrap();
     let room = Room::find(&connection, &RoomId::try_from("!admin:localhost").unwrap()).unwrap();
@@ -159,7 +159,7 @@ fn bot_ignoeres_when_a_user_leaves_a_room_that_is_not_in_the_database() {
     let mut matrix_router = Router::new();
     matrix_router.post(LeaveRoomEndpoint::router_path(), leave_message_forwarder, "leave_room");
     matrix_router.post(ForgetRoomEndpoint::router_path(), forget_message_forwarder, "forget_room");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).with_admin_room().run();
+    let test = Test::new().with_matrix_routes(matrix_router).with_admin_room().run();
 
     helpers::leave_room(&test.config.as_url,
                         RoomId::try_from("!unknown:localhost").unwrap(),
@@ -187,7 +187,7 @@ fn the_user_gets_a_message_when_joining_the_room_failes_for_the_bot_user() {
     };
     matrix_router.get(GetMemberEventsEndpoint::router_path(), room_members, "get_member_events");
     matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).run();
+    let test = Test::new().with_matrix_routes(matrix_router).run();
 
     helpers::invite(&test.config.as_url,
                     RoomId::try_from("!admin:localhost").unwrap(),
@@ -216,7 +216,7 @@ fn the_user_gets_a_message_when_getting_the_room_members_failes() {
     };
     matrix_router.get(GetMemberEventsEndpoint::router_path(), error_responder, "get_member_events");
     matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).run();
+    let test = Test::new().with_matrix_routes(matrix_router).run();
 
     helpers::create_admin_room(&test.config.as_url,
                                RoomId::try_from("!admin:localhost").unwrap(),
@@ -243,7 +243,7 @@ fn the_user_gets_a_message_when_the_room_members_cannot_be_deserialized() {
                       handlers::InvalidJsonResponse { status: status::Ok },
                       "get_member");
     matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).run();
+    let test = Test::new().with_matrix_routes(matrix_router).run();
 
     helpers::create_admin_room(&test.config.as_url,
                                RoomId::try_from("!admin:localhost").unwrap(),
@@ -281,7 +281,7 @@ fn the_user_gets_a_message_when_setting_the_room_display_name_fails() {
     };
     matrix_router.get(GetMemberEventsEndpoint::router_path(), room_members, "get_member_events");
     matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).run();
+    let test = Test::new().with_matrix_routes(matrix_router).run();
 
     helpers::create_admin_room(&test.config.as_url,
                                RoomId::try_from("!admin:localhost").unwrap(),
@@ -321,7 +321,7 @@ fn the_user_gets_a_message_when_an_leaving_the_room_failes_for_the_bot_user() {
         message: "Could not leave room".to_string(),
     };
     matrix_router.post(LeaveRoomEndpoint::router_path(), error_responder, "leave_room");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).run();
+    let test = Test::new().with_matrix_routes(matrix_router).run();
 
     helpers::create_admin_room(&test.config.as_url,
                                RoomId::try_from("!admin:localhost").unwrap(),
@@ -351,7 +351,7 @@ fn the_user_gets_a_message_when_forgetting_the_room_failes_for_the_bot_user() {
         message: "Could not forget room".to_string(),
     };
     matrix_router.post(ForgetRoomEndpoint::router_path(), error_responder, "forget_room");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).run();
+    let test = Test::new().with_matrix_routes(matrix_router).run();
 
     helpers::create_admin_room(&test.config.as_url,
                                RoomId::try_from("!admin:localhost").unwrap(),
@@ -380,7 +380,7 @@ fn bot_leaves_when_a_third_user_joins_the_admin_room() {
     matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
     matrix_router.post(LeaveRoomEndpoint::router_path(), leave_forwarder, "leave");
     matrix_router.post(ForgetRoomEndpoint::router_path(), forget_forwarder, "forget");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).run();
+    let test = Test::new().with_matrix_routes(matrix_router).run();
 
     helpers::create_admin_room(&test.config.as_url,
                                RoomId::try_from("!admin:localhost").unwrap(),
@@ -420,7 +420,7 @@ fn unkown_membership_states_are_skipped() {
     let (message_forwarder, receiver) = MessageForwarder::new();
     let mut matrix_router = Router::new();
     matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).run();
+    let test = Test::new().with_matrix_routes(matrix_router).run();
 
     let unknown_event = MemberEvent {
         content: MemberEventContent {

--- a/tests/event_dispatcher.rs
+++ b/tests/event_dispatcher.rs
@@ -18,7 +18,7 @@ fn error_message_language_falls_back_to_the_default_language_if_the_sender_is_no
     let mut matrix_router = Router::new();
     let (message_forwarder, receiver) = MessageForwarder::new();
     matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).run();
+    let test = Test::new().with_matrix_routes(matrix_router).run();
 
     helpers::join(&test.config.as_url,
                   RoomId::try_from("!admin:localhost").unwrap(),

--- a/tests/matrix-rocketchat-test/handlers.rs
+++ b/tests/matrix-rocketchat-test/handlers.rs
@@ -15,9 +15,7 @@ pub struct RocketchatInfo {
 impl Handler for RocketchatInfo {
     fn handle(&self, _request: &mut Request) -> IronResult<Response> {
         let payload = r#"{
-            "info": {
-                "version": "VERSION"
-            }
+            "version": "VERSION"
         }"#
             .replace("VERSION", self.version);
 

--- a/tests/matrix-rocketchat-test/handlers.rs
+++ b/tests/matrix-rocketchat-test/handlers.rs
@@ -8,6 +8,24 @@ use ruma_identifiers::{EventId, RoomId, UserId};
 use serde_json;
 
 #[derive(Serialize)]
+pub struct RocketchatInfo {
+    pub version: &'static str,
+}
+
+impl Handler for RocketchatInfo {
+    fn handle(&self, _request: &mut Request) -> IronResult<Response> {
+        let payload = r#"{
+            "info": {
+                "version": "VERSION"
+            }
+        }"#
+            .replace("VERSION", self.version);
+
+        Ok(Response::with((status::Ok, payload)))
+    }
+}
+
+#[derive(Serialize)]
 pub struct MatrixVersion {
     pub versions: Vec<&'static str>,
 }

--- a/tests/matrix-rocketchat-test/helpers.rs
+++ b/tests/matrix-rocketchat-test/helpers.rs
@@ -6,6 +6,7 @@ use reqwest::{Method, StatusCode};
 use ruma_events::EventType;
 use ruma_events::collections::all::Event;
 use ruma_events::room::member::{MemberEvent, MemberEventContent, MembershipState};
+use ruma_events::room::message::{MessageEvent, MessageEventContent, MessageType, TextMessageEventContent};
 use ruma_identifiers::{EventId, RoomId, UserId};
 use serde_json::to_string;
 use super::HS_TOKEN;
@@ -87,6 +88,25 @@ pub fn leave_room(as_url: &str, room_id: RoomId, user_id: UserId) {
     let leave_payload = to_string(&events).unwrap();
 
     simulate_message_from_matrix(as_url, &leave_payload);
+}
+
+pub fn send_room_message_from_matrix(as_url: &str, room_id: RoomId, user_id: UserId, body: String) {
+    let message_event = MessageEvent {
+        content: MessageEventContent::Text(TextMessageEventContent {
+            body: body,
+            msgtype: MessageType::Text,
+        }),
+        event_id: EventId::new("localhost").unwrap(),
+        event_type: EventType::RoomMessage,
+        room_id: room_id,
+        unsigned: None,
+        user_id: user_id,
+    };
+
+    let events = Events { events: vec![Box::new(Event::RoomMessage(message_event))] };
+    let payload = to_string(&events).unwrap();
+
+    simulate_message_from_matrix(as_url, &payload);
 }
 
 pub fn simulate_message_from_matrix(as_url: &str, payload: &str) -> (String, StatusCode) {

--- a/tests/matrix-rocketchat-test/helpers.rs
+++ b/tests/matrix-rocketchat-test/helpers.rs
@@ -109,6 +109,25 @@ pub fn send_room_message_from_matrix(as_url: &str, room_id: RoomId, user_id: Use
     simulate_message_from_matrix(as_url, &payload);
 }
 
+pub fn send_emote_message_from_matrix(as_url: &str, room_id: RoomId, user_id: UserId, body: String) {
+    let message_event = MessageEvent {
+        content: MessageEventContent::Text(TextMessageEventContent {
+            body: body,
+            msgtype: MessageType::Emote,
+        }),
+        event_id: EventId::new("localhost").unwrap(),
+        event_type: EventType::RoomMessage,
+        room_id: room_id,
+        unsigned: None,
+        user_id: user_id,
+    };
+
+    let events = Events { events: vec![Box::new(Event::RoomMessage(message_event))] };
+    let payload = to_string(&events).unwrap();
+
+    simulate_message_from_matrix(as_url, &payload);
+}
+
 pub fn simulate_message_from_matrix(as_url: &str, payload: &str) -> (String, StatusCode) {
     let url = format!("{}/transactions/{}", as_url, "specid");
     let mut params = HashMap::new();

--- a/tests/matrix-rocketchat-test/lib.rs
+++ b/tests/matrix-rocketchat-test/lib.rs
@@ -199,7 +199,7 @@ impl Test {
                    "versions");
         router.post("*", handlers::EmptyJson {}, "default_post");
         router.put("*", handlers::EmptyJson {}, "default_put");
-        if self.with_admin_room {
+        if self.with_admin_room || self.with_connected_admin_room {
             let room_members = handlers::RoomMembers {
                 room_id: RoomId::try_from("!admin:localhost").unwrap(),
                 members: vec![UserId::try_from("@spec_user:localhost").unwrap(),

--- a/tests/matrix-rocketchat-test/lib.rs
+++ b/tests/matrix-rocketchat-test/lib.rs
@@ -59,6 +59,8 @@ const AS_TOKEN: &'static str = "at";
 pub const HS_TOKEN: &'static str = "ht";
 /// Number of threads that iron uses when running tests
 pub const IRON_THREADS: usize = 1;
+/// The version the mock Rocket.Chat server announces
+pub const DEFAULT_ROCKETCHAT_VERSION: &'static str = "0.49.0";
 
 lazy_static! {
     /// Default logger
@@ -199,7 +201,10 @@ impl Test {
     fn run_rocketchat_server_mock(&mut self) {
         let (tx, rx) = channel::<Listening>();
         let socket_addr = get_free_socket_addr();
-        let router = Router::new();
+        let mut router = Router::new();
+        router.get("/api/info",
+                   handlers::RocketchatInfo { version: DEFAULT_ROCKETCHAT_VERSION },
+                   "info");
 
         thread::spawn(move || {
             let mut server = Iron::new(router);

--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -39,7 +39,7 @@ fn unknown_event_types_are_skipped() {
     let (message_forwarder, receiver) = MessageForwarder::new();
     let mut matrix_router = Router::new();
     matrix_router.put(SendMessageEventEndpoint::router_path(), message_forwarder, "send_message_event");
-    let test = Test::new().with_custom_matrix_routes(matrix_router).run();
+    let test = Test::new().with_matrix_routes(matrix_router).run();
 
     let unknown_event = HangupEvent {
         content: HangupEventContent {


### PR DESCRIPTION
Users can now connect an admin room to a Rocket.Chat server via `connect https://example.com secret_token`