### PR TITLE
Fix test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ script:
       cargo test
 
 after_success:
-  - cargo coveralls
+  - cargo coveralls --exclude-pattern src/bin/,target/,tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 
 language: rust
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "isatty"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -977,7 +977,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "isatty 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "isatty 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1242,7 +1242,7 @@ dependencies = [
 "checksum hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "72332e4a35d3059583623b50e98e491b78f8b96c5521fcb3f428167955aa56e8"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2440ae846e7a8c7f9b401db8f6e31b4ea5e7d3688b91761337da7e054520c75b"
-"checksum isatty 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fa500db770a99afe2a0f2229be2a3d09c7ed9d7e4e8440bf71253141994e240f"
+"checksum isatty 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "00c9301a947a2eaee7ce2556b80285dcc89558d07088962e6e8b9c25730f9dc6"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "matrix_rocketchat"
 path = "src/matrix-rocketchat/lib.rs"
 
 [dependencies]
-clap = { version = "2.24" }
+clap = "2.26"
 diesel = { version = "0.12", default-features = false, features = ["sqlite"] }
 diesel_codegen = { version = "0.12", default-features = false, features = ["sqlite"] }
 error-chain = "0.11"
@@ -34,7 +34,7 @@ slog-async = "2.1"
 slog-json = "2.0"
 slog-term = "2.2"
 slog-stream = "1.2"
-url = "1.4"
+url = "1.5"
 yaml-rust = "0.3"
 
 [dev-dependencies]

--- a/src/matrix-rocketchat/config.rs
+++ b/src/matrix-rocketchat/config.rs
@@ -55,10 +55,4 @@ impl Config {
         let user_id = format!("@{}:{}", &self.sender_localpart, &self.hs_domain);
         UserId::try_from(&user_id).chain_err(|| ErrorKind::InvalidUserId(user_id)).map_err(Error::from)
     }
-
-    /// Check if the user ID is part of the application service namespace
-    pub fn is_application_service_user(&self, matrix_user_id: &UserId) -> bool {
-        let id_prefix = format!("@{}", self.sender_localpart);
-        matrix_user_id.to_string().starts_with(&id_prefix)
-    }
 }


### PR DESCRIPTION
`cargo travis` doesn't filter any files, which caused some files from the target and test directory to be included when calculating the code coverage.