### PR TITLE
Use the joined room API to do less API calls

### DIFF
--- a/src/matrix-rocketchat/api/rocketchat/mod.rs
+++ b/src/matrix-rocketchat/api/rocketchat/mod.rs
@@ -45,7 +45,7 @@ pub struct Attachment {
 }
 
 /// A Rocket.Chat channel
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Serialize)]
 pub struct Channel {
     /// ID of the Rocket.Chat room
     #[serde(rename = "_id")]
@@ -93,6 +93,8 @@ pub trait RocketchatApi {
     fn direct_messages_list(&self) -> Result<Vec<Channel>>;
     /// Get the url of an image that is attached to a message.
     fn get_attachments(&self, message_id: &str) -> Result<Vec<Attachment>>;
+    /// Get all the channels that the user of the request has joiend.
+    fn get_joined_channels(&self) -> Result<Vec<Channel>>;
     /// Login a user on the Rocket.Chat server
     fn login(&self, username: &str, password: &str) -> Result<(String, String)>;
     /// Get all members of a channel

--- a/src/matrix-rocketchat/handlers/matrix/command_handler.rs
+++ b/src/matrix-rocketchat/handlers/matrix/command_handler.rs
@@ -372,16 +372,15 @@ impl<'a> CommandHandler<'a> {
         rocketchat_server_id: &str,
         user_id: &UserId,
     ) -> Result<String> {
-        let display_name = rocketchat_api.current_username()?;
         let channels = rocketchat_api.channels_list()?;
+        let joined_channels = rocketchat_api.get_joined_channels()?;
 
         let mut channel_list = "".to_string();
         for c in channels {
             let channel = Channel::new(self.config, self.logger, self.matrix_api, c.id.clone(), rocketchat_server_id);
-            let users = rocketchat_api.members(&c.id)?;
             let formatter = if channel.is_bridged_for_user(user_id)? {
                 "**"
-            } else if users.iter().any(|u| u.username == display_name) {
+            } else if joined_channels.iter().any(|jc| jc.id == c.id) {
                 "*"
             } else {
                 ""

--- a/tests/admin_commands_list.rs
+++ b/tests/admin_commands_list.rs
@@ -12,7 +12,7 @@ use std::convert::TryFrom;
 
 use iron::status;
 use matrix_rocketchat::api::MatrixApi;
-use matrix_rocketchat::api::rocketchat::v1::{CHANNELS_LIST_PATH, LOGIN_PATH, ME_PATH};
+use matrix_rocketchat::api::rocketchat::v1::{CHANNELS_LIST_PATH, GET_JOINED_CHANNELS_PATH, LOGIN_PATH, ME_PATH};
 use matrix_rocketchat_test::{default_timeout, handlers, helpers, MessageForwarder, Test, DEFAULT_LOGGER};
 use router::Router;
 use ruma_client_api::Endpoint;
@@ -36,6 +36,15 @@ fn sucessfully_list_rocketchat_rooms() {
             username: "spec_user".to_string(),
         },
         "me",
+    );
+    let mut users_in_rooms = HashMap::new();
+    users_in_rooms.insert("spec_user_id", vec!["joined_channel", "bridged_channel"]);
+    rocketchat_router.get(
+        GET_JOINED_CHANNELS_PATH,
+        handlers::RocketchatJoinedRooms {
+            users_in_rooms: users_in_rooms,
+        },
+        "joined_channels",
     );
 
     let test = test.with_matrix_routes(matrix_router)


### PR DESCRIPTION
Instead of querying the room members for each room individually, there is now a new endpoint to get all the rooms a user has joined.