### PR TITLE
Add HTTPS support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-native-tls"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +473,7 @@ dependencies = [
  "diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_migrations 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matrix_rocketchat_test 0.1.0",
@@ -1530,6 +1541,7 @@ dependencies = [
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum hyper 0.11.12 (registry+https://github.com/rust-lang/crates.io-index)" = "856a5eb897fbc26890ddf8760ad4bbfc6bd777233522d9c48379ca9563d40517"
+"checksum hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "72332e4a35d3059583623b50e98e491b78f8b96c5521fcb3f428167955aa56e8"
 "checksum hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c81fa95203e2a6087242c38691a0210f23e9f3f8f944350bd676522132e2985"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ clap = "2.2"
 diesel = { version = "1.0", default-features = false, features = ["sqlite"] }
 diesel_migrations = { version = "1.0", default-features = false, features = ["sqlite"] }
 error-chain = "0.11"
+hyper-native-tls = "0.2"
 iron = "0.6"
 lazy_static = "1.0"
 num_cpus = "1.8"

--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -10,18 +10,18 @@ as_token: "as_secret_token"
 # application service without a reverse proxy, this has to be a public IP
 # address of your server. You can choose any IP/port that is available on your
 # server. 0.0.0.0 binds to all interfaces.
-as_address: "0.0.0.0:8088"
+as_address: "0.0.0.0:8822"
 # The URL which can be used to access the application service. If you type this
 # URL in your browser after you started the application service you should see
 # "Your Rocket.Chat <-> Matrix application service is running".
 # It can be a domain that points to the public IP address of your server or the
 # IP address itself.
 # This has to match the parameter `url` in your  rocketchat_registration.yaml.
-as_url: "https://example.com:8088"
+as_url: "https://example.com:8822"
 # The URL which can be used to access your homeserver. If the homeserver is
 # running on the same machine you can use the non SSL port 8008. If the
 # homeserver is running on another machine, use the servername with the SSL
-# port (e.g. https://example.org:8448).
+# port (e.g. https://example.org:8822).
 hs_url: "http://127.0.0.1:8008"
 # The domain of the homeserver. It is used to create the usernames (the part
 # after the colon).
@@ -50,14 +50,14 @@ log_file_path: "/path/to/file.log"
 # Which means that users from other homeservers can use this Rocket.Chat bridge
 # if the flag is set to true.
 accept_remote_invites: false
-# Flag that indicates if the application service should use SSL. It's highly
-# recommended that you use SSL if you expose the application service directly
+# Flag that indicates if the application service should use HTTPS. It's highly
+# recommended that you use HTTPS if you expose the application service directly
 # (bind it to a public IP address). If you run the application service behind
-# a reverse-proxy you can run it on localhost and let the proxy handle SSL.
-use_ssl: true
-# Path to the SSL certificate (this is only mandatory if you run the
+# a reverse-proxy you can run it on localhost and let the proxy handle HTTPS.
+use_https: true
+# Path to the PKCS 12 file (this is only mandatory if you run the
 # application service with SSL).
-ssl_certificate_path: "/etc/letsencrypt/live/example.com/fullchain.pem"
-# Path to the SSL key (this is only mandatory if you run the application
-# service with SSL).
-ssl_key_path: "/etc/letsencrypt/live/example.com/privkey.pem"
+pkcs12_path: "/etc/letsencrypt/live/example.com/file.pk12"
+# The password to decrypt the PKCS 12 file (this is only mandatory if you run the
+# application service with SSL).
+pkcs12_password: "secret"

--- a/src/matrix-rocketchat/config.rs
+++ b/src/matrix-rocketchat/config.rs
@@ -39,11 +39,11 @@ pub struct Config {
     /// Path to the log file (this is only mandatory if logging to a file is enabled)
     pub log_file_path: String,
     /// Flag to indicate if the application service should use HTTPS
-    pub use_ssl: bool,
-    /// Path to the SSL certificate (only needed if SSL is used)
-    pub ssl_certificate_path: Option<String>,
-    /// Path to the SSL key (only needed if SSL is used)
-    pub ssl_key_path: Option<String>,
+    pub use_https: bool,
+    /// Path to the PKCS 12 file
+    pub pkcs12_path: Option<String>,
+    /// Password to decrypt the PKCS 12 file
+    pub pkcs12_password: Option<String>,
 }
 
 impl Config {

--- a/src/matrix-rocketchat/lib.rs
+++ b/src/matrix-rocketchat/lib.rs
@@ -10,6 +10,7 @@ extern crate diesel;
 extern crate diesel_migrations;
 #[macro_use]
 extern crate error_chain;
+extern crate hyper_native_tls;
 extern crate iron;
 #[macro_use]
 extern crate lazy_static;

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -14,8 +14,8 @@ use tempdir::TempDir;
 fn read_config_from_file() {
     let config_data = r#"hs_token: "hs_token"
                         as_token: "as_token"
-                        as_address: "127.0.0.1:8088"
-                        as_url: "http://localhost:8088"
+                        as_address: "127.0.0.1:8822"
+                        as_url: "http://localhost:8822"
                         hs_url: "http://localhost:8008"
                         hs_domain: "matrix.local"
                         sender_localpart: "rocketchat"
@@ -25,7 +25,7 @@ fn read_config_from_file() {
                         log_to_console: true
                         log_to_file: true
                         log_file_path: "matrix-rocketchat.log"
-                        use_ssl: false"#.replace("  ", ""); // hacky way to remove the whitespaces before the keys
+                        use_https: false"#.replace("  ", ""); // hacky way to remove the whitespaces before the keys
     let temp_dir = TempDir::new(TEMP_DIR_NAME).unwrap();
     let config_path = temp_dir.path().join("test.config");
 
@@ -34,8 +34,8 @@ fn read_config_from_file() {
     let config = Config::read_from_file(config_path.to_str().unwrap()).unwrap();
     assert_eq!(config.hs_token, "hs_token".to_string());
     assert_eq!(config.as_token, "as_token".to_string());
-    assert_eq!(config.as_address, "127.0.0.1:8088".to_socket_addrs().unwrap().next().unwrap());
-    assert_eq!(config.as_url, "http://localhost:8088");
+    assert_eq!(config.as_address, "127.0.0.1:8822".to_socket_addrs().unwrap().next().unwrap());
+    assert_eq!(config.as_url, "http://localhost:8822");
     assert_eq!(config.hs_url, "http://localhost:8008");
     assert_eq!(config.hs_domain, "matrix.local");
     assert_eq!(config.sender_localpart, "rocketchat");
@@ -45,5 +45,5 @@ fn read_config_from_file() {
     assert_eq!(config.log_to_console, true);
     assert_eq!(config.log_to_file, true);
     assert_eq!(config.log_file_path, "matrix-rocketchat.log");
-    assert_eq!(config.use_ssl, false);
+    assert_eq!(config.use_https, false);
 }

--- a/tests/matrix-rocketchat-test/lib.rs
+++ b/tests/matrix-rocketchat-test/lib.rs
@@ -610,9 +610,9 @@ pub fn build_test_config(temp_dir: &TempDir) -> Config {
         log_to_console: true,
         log_to_file: false,
         log_file_path: "".to_string(),
-        use_ssl: false,
-        ssl_certificate_path: None,
-        ssl_key_path: None,
+        use_https: false,
+        pkcs12_path: None,
+        pkcs12_password: None,
     }
 }
 


### PR DESCRIPTION
Allow a user to provide the SSL certificate directly instead of using the applications service behind a reverse proxy.