### PR TITLE
Log levels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2-diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ruma-client-api 0.1.0 (git+https://github.com/exul/ruma-client-api.git)",
@@ -978,8 +979,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1863,7 +1884,9 @@ dependencies = [
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
+"checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+"checksum regex-syntax 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05b06a75f5217880fc5e905952a42750bf44787e56a6c6d6852ed0992f5e1d54"
 "checksum relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "241faa9a8ca28a03cbbb9815a5d085f271d4c0168a19181f106aa93240c22ddb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ persistent = "0.4"
 pulldown-cmark = "0.1"
 r2d2 = "0.8"
 r2d2-diesel = "1.0"
+regex = "1.0.0"
 reqwest = "0.8"
 router = "0.6"
 ruma-client-api = { git = "https://github.com/exul/ruma-client-api.git" }

--- a/src/matrix-rocketchat/api/rocketchat/v1.rs
+++ b/src/matrix-rocketchat/api/rocketchat/v1.rs
@@ -523,7 +523,7 @@ impl super::RocketchatApi for RocketchatApi {
             for attachment in attachments {
                 debug!(self.logger, "Getting file {}", attachment.title_link);
 
-                let mut get_file_endpoint = GetFileEndpoint {
+                let get_file_endpoint = GetFileEndpoint {
                     base_url: self.base_url.clone(),
                     user_id: self.user_id.clone(),
                     auth_token: self.auth_token.clone(),

--- a/src/matrix-rocketchat/api/rocketchat/v1.rs
+++ b/src/matrix-rocketchat/api/rocketchat/v1.rs
@@ -979,7 +979,7 @@ fn build_error(endpoint: &str, body: &str, status_code: &StatusCode) -> Error {
 
     if *status_code == StatusCode::Unauthorized {
         return Error {
-            error_chain: ErrorKind::AuthenticationFailed(rocketchat_error_resp.message.unwrap_or_default()).into(),
+            error_chain: ErrorKind::RocketchatAuthenticationFailed(rocketchat_error_resp.message.unwrap_or_default()).into(),
             user_message: Some(t!(["errors", "authentication_failed"])),
         };
     }

--- a/src/matrix-rocketchat/api/rocketchat/v1.rs
+++ b/src/matrix-rocketchat/api/rocketchat/v1.rs
@@ -549,7 +549,7 @@ impl super::RocketchatApi for RocketchatApi {
                 files.push(rocketchat_attachment);
             }
         } else {
-            info!(self.logger, "No attachments found for message ID {}", message_id);
+            debug!(self.logger, "No attachments found for message ID {}", message_id);
         }
 
         Ok(files)

--- a/src/matrix-rocketchat/errors.rs
+++ b/src/matrix-rocketchat/errors.rs
@@ -168,9 +168,9 @@ error_chain!{
             display("Unsupported HTTP method {}", method)
         }
 
-        AuthenticationFailed(error_msg: String) {
-            description("Authentication failed")
-            display("Authentication failed: {}", error_msg)
+        RocketchatAuthenticationFailed(error_msg: String) {
+            description("Rocket.Chat authentication failed")
+            display("User login on Rocket.Chat server failed: {}", error_msg)
         }
 
         ApiCallFailed(url: String) {
@@ -398,9 +398,9 @@ impl Error {
     pub fn status_code(&self) -> Status {
         match *self.error_chain {
             ErrorKind::InvalidAccessToken(_) | ErrorKind::InvalidRocketchatToken(_) => Status::Forbidden,
-            ErrorKind::MissingAccessToken | ErrorKind::MissingRocketchatToken | ErrorKind::AuthenticationFailed(_) => {
-                Status::Unauthorized
-            }
+            ErrorKind::MissingAccessToken
+            | ErrorKind::MissingRocketchatToken
+            | ErrorKind::RocketchatAuthenticationFailed(_) => Status::Unauthorized,
             ErrorKind::InvalidJSON(_) => Status::UnprocessableEntity,
             ErrorKind::AdminRoomForRocketchatServerNotFound(_) => Status::NotFound,
             _ => Status::InternalServerError,

--- a/src/matrix-rocketchat/handlers/error_notifier.rs
+++ b/src/matrix-rocketchat/handlers/error_notifier.rs
@@ -1,3 +1,4 @@
+use regex::{Captures, Regex};
 use ruma_identifiers::RoomId;
 use slog::Logger;
 
@@ -5,6 +6,10 @@ use api::MatrixApi;
 use config::Config;
 use errors::*;
 use i18n::*;
+
+lazy_static! {
+    static ref MATRIX_ID_REGEX: Regex = Regex::new("@([0-9A-Za-z.-_]+):([0-9A-Za-z.-]+)").expect("compiling regex failed");
+}
 
 /// Notifies the user about errors
 pub struct ErrorNotifier<'a> {
@@ -28,10 +33,16 @@ impl<'a> ErrorNotifier<'a> {
         let matrix_bot_id = self.config.matrix_bot_user_id()?;
         let user_message = match err.user_message {
             Some(ref user_message) => {
+                if self.config.log_level != "debug" {
+                    msg = obfuscate_mxid(&msg);
+                }
                 info!(self.logger, "{}", msg);
                 user_message
             }
             None => {
+                if self.config.log_level != "debug" {
+                    msg = obfuscate_mxid(&msg);
+                }
                 error!(self.logger, "{}", msg);
                 let user_msg = t!(["defaults", "internal_error"]).l(DEFAULT_LANGUAGE);
                 return self.matrix_api.send_text_message(room_id, matrix_bot_id, user_msg);
@@ -40,4 +51,14 @@ impl<'a> ErrorNotifier<'a> {
 
         self.matrix_api.send_text_message(room_id, matrix_bot_id, user_message.l(DEFAULT_LANGUAGE))
     }
+}
+
+fn obfuscate_mxid(msg: &str) -> String {
+    MATRIX_ID_REGEX
+        .replace_all(&msg, |caps: &Captures| {
+            let a: String = caps[1].chars().map(|_| '*').collect();
+            let b: String = caps[2].chars().map(|_| '*').collect();
+            format!("@{}:{}", a, b)
+        })
+        .into_owned()
 }

--- a/src/matrix-rocketchat/handlers/iron/rocketchat_login.rs
+++ b/src/matrix-rocketchat/handlers/iron/rocketchat_login.rs
@@ -1,14 +1,14 @@
 use std::io::Read;
 
-use iron::{status, Handler};
 use iron::prelude::*;
 use iron::request::Body;
+use iron::{status, Handler};
 use serde_json;
 
-use i18n::*;
 use api::MatrixApi;
 use config::Config;
 use errors::*;
+use i18n::*;
 use log::IronLogger;
 use models::{ConnectionPool, Credentials, RocketchatServer};
 
@@ -23,7 +23,7 @@ pub struct RocketchatLogin {
 impl Handler for RocketchatLogin {
     fn handle(&self, request: &mut Request) -> IronResult<Response> {
         let logger = IronLogger::from_request(request)?;
-        debug!(logger, "Received login command via REST API");
+        info!(logger, "Received login command via REST API");
 
         let connection = ConnectionPool::from_request(request)?;
         let credentials = deserialize_credentials(&mut request.body)?;

--- a/src/matrix-rocketchat/handlers/matrix/command_handler.rs
+++ b/src/matrix-rocketchat/handlers/matrix/command_handler.rs
@@ -128,12 +128,7 @@ impl<'a> CommandHandler<'a> {
                 )?;
                 self.matrix_api.send_text_message(self.admin_room.id.clone(), self.config.matrix_bot_user_id()?, body)?;
 
-                info!(
-                    self.logger,
-                    "Successfully executed connect command for user {} and Rocket.Chat server {}",
-                    event.user_id,
-                    rocketchat_url
-                );
+                info!(self.logger, "Successfully executed connect command for Rocket.Chat server {}", rocketchat_url);
                 Ok(())
             })
             .map_err(Error::from)
@@ -201,7 +196,7 @@ impl<'a> CommandHandler<'a> {
         let bot_user_id = self.config.matrix_bot_user_id()?;
         self.matrix_api.send_text_message(self.admin_room.id.clone(), bot_user_id, help_message)?;
 
-        info!(self.logger, "Successfully executed help command for user {}", event.user_id);
+        debug!(self.logger, "Successfully executed help command for user {}", event.user_id);
         Ok(())
     }
 

--- a/src/matrix-rocketchat/handlers/matrix/dispatcher.rs
+++ b/src/matrix-rocketchat/handlers/matrix/dispatcher.rs
@@ -74,7 +74,7 @@ impl<'a> Dispatcher<'a> {
         };
 
         if let Err(send_err) = error_notifier.send_message_to_user(err, room_id.clone()) {
-            debug!(self.logger, "Unable to send an error message to the user");
+            warn!(self.logger, "Unable to send an error message to the user in room {}", room_id);
             log::log_debug(self.logger, err);
             return Err(send_err);
         }

--- a/src/matrix-rocketchat/handlers/matrix/forwarder.rs
+++ b/src/matrix-rocketchat/handlers/matrix/forwarder.rs
@@ -63,7 +63,7 @@ impl<'a> Forwarder<'a> {
                 self.forward_file_to_rocketchat(rocketchat_api.as_ref(), &content.url, mimetype, &content.body, channel_id)?;
             }
             MessageEventContent::Emote(_) | MessageEventContent::Location(_) | MessageEventContent::Notice(_) => {
-                info!(self.logger, "Forwarding the type {} is not implemented.", event.event_type)
+                info!(self.logger, "Not forwarding message, forwarding emote, location or notice messages is not implemented.")
             }
         }
 

--- a/src/matrix-rocketchat/handlers/rocketchat/forwarder.rs
+++ b/src/matrix-rocketchat/handlers/rocketchat/forwarder.rs
@@ -121,7 +121,7 @@ impl<'a> Forwarder<'a> {
         };
 
         if receiver.rocketchat_user_id.clone().unwrap_or_default() == message.user_id {
-            info!(self.logger, "Not forwarding direct message, because the sender is the receivers virtual user");
+            debug!(self.logger, "Not forwarding direct message, because the sender is the receivers virtual user");
             return Ok(None);
         }
 
@@ -213,7 +213,7 @@ impl<'a> Forwarder<'a> {
             // the bot will leave as soon as the AS gets the join event
             let invitee_id = self.config.matrix_bot_user_id()?;
             self.matrix_api.invite(room_id.clone(), invitee_id.clone(), sender_id.clone())?;
-            debug!(self.logger, "Direct message room {} successfully created", &room_id);
+            info!(self.logger, "Direct message room {} successfully created", &room_id);
 
             let room = Room::new(self.config, self.logger, self.matrix_api, room_id);
             Ok(Some(room))

--- a/src/matrix-rocketchat/lib.rs
+++ b/src/matrix-rocketchat/lib.rs
@@ -18,6 +18,7 @@ extern crate persistent;
 extern crate pulldown_cmark;
 extern crate r2d2;
 extern crate r2d2_diesel;
+extern crate regex;
 extern crate reqwest;
 extern crate router;
 extern crate ruma_client_api;

--- a/src/matrix-rocketchat/lib.rs
+++ b/src/matrix-rocketchat/lib.rs
@@ -1,6 +1,6 @@
 //! Application service to bridge Matrix <-> Rocket.Chat.
 
-#![feature(try_from)]
+#![feature(try_from, nll)]
 #![deny(missing_docs)]
 #![recursion_limit = "256"]
 

--- a/src/matrix-rocketchat/models/rocketchat_server.rs
+++ b/src/matrix-rocketchat/models/rocketchat_server.rs
@@ -137,12 +137,7 @@ impl RocketchatServer {
             matrix_api.send_text_message(room_id, bot_user_id, message)?;
         }
 
-        info!(
-            logger,
-            "Successfully executed login command for user {} on Rocket.Chat server {}",
-            credentials.rocketchat_username,
-            self.rocketchat_url
-        );
+        info!(logger, "Successfully executed login command on Rocket.Chat server {}", self.rocketchat_url);
 
         Ok(())
     }

--- a/src/matrix-rocketchat/models/room.rs
+++ b/src/matrix-rocketchat/models/room.rs
@@ -277,7 +277,7 @@ impl<'a> Room<'a> {
     pub fn join_user(&self, user_id: UserId, inviting_user_id: UserId) -> Result<()> {
         let user_joined_already = self.user_ids(Some(inviting_user_id.clone()))?.iter().any(|id| id == &user_id);
         if !user_joined_already {
-            info!(self.logger, "Adding virtual user {} to room {}", user_id, self.id);
+            debug!(self.logger, "Adding virtual user {} to room {}", user_id, self.id);
             self.matrix_api.invite(self.id.clone(), user_id.clone(), inviting_user_id)?;
 
             if user_id.to_string().starts_with(&format!("@{}", self.config.sender_localpart)) {


### PR DESCRIPTION
Adjust log levels and fix Rocket.Chat error responses (`error` can be either a number or a string).